### PR TITLE
Fix variable reference before assignment error in light curve fitting

### DIFF
--- a/nmma/em/analysis.py
+++ b/nmma/em/analysis.py
@@ -618,7 +618,7 @@ def main():
             model_colors = cm.Spectral(np.linspace(0, 1, len(models)))[::-1]
 
         filters_plot = []
-        for filt in filters:
+        for filt in filters_to_analyze:
             if filt not in data:
                 continue
             samples = data[filt]
@@ -722,7 +722,7 @@ def main():
                         shadow=True,
                         fancybox=True,
                     )
-            elif not cnt == len(filters):
+            elif not cnt == len(filters_plot):
                 plt.setp(ax2.get_xticklabels(), visible=False)
             plt.xticks(fontsize=36)
             plt.yticks(fontsize=36)


### PR DESCRIPTION
Running the light curve fitting example in the docs:
```
light_curve_analysis --model Bu2019lm --svd-path ./svdmodels --interpolation_type tensorflow --outdir outdir --label injection --prior priors/Bu2019lm.prior --tmin 0.1 --tmax 20 --dt 0.5 --error-budget 1 --nlive 512 --Ebv-max 0 --trigger-time 59397.28347219899 --data example_files/candidate_data/ZTF21abjvfbc.dat --plot --sampler dynesty
```
fails with `UnboundLocalError: local variable 'filters' referenced before assignment`. It appears that the `filters` variable in `em/analysis.py` will only exist for some choices of input arguments, which can lead to this error for certain configurations.

This patch changes two references to `filters` where this error can occur to alternatives in the code that should exist in any case.