### PR TITLE
Remove extraneous characters from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,8 +14,8 @@ dust_extinction
 wrapt_timeout_decorator
 arviz
 ### for mpi ###
-"parallel_bilby>=1.0.0",
-"mpi4py",
+parallel_bilby>=1.0.0
+mpi4py
 ### for docs ###
 sphinx==4.4.0
 recommonmark


### PR DESCRIPTION
Trying to install dependencies via `pip install -r requirements.txt` fails with the error `ERROR: Invalid requirement: '"parallel_bilby>=1.0.0",' (from line 17 of requirements.txt)` due to the presence of double-quote and comma characters. This patch removes those extra characters from two lines in `requirements.txt` to allow for installing dependencies separately.