### PR TITLE
Switch to using tensorflow model __call__

### DIFF
--- a/nmma/em/utils.py
+++ b/nmma/em/utils.py
@@ -367,7 +367,7 @@ def calc_lc(
 
         if interpolation_type == "tensorflow":
             model = svd_mag_model[filt]["model"]
-            cAproj = model.predict(np.atleast_2d(param_list_postprocess)).T.flatten()
+            cAproj = model(np.atleast_2d(param_list_postprocess)).numpy().T.flatten()
             cAstd = np.ones((n_coeff,))
         elif interpolation_type == "api_gp":
             seed = 32


### PR DESCRIPTION
This patch changes light curve generation in `calc_lc` when using a tensorflow model to the model's `__call__` method instead of `predict`. The [tensorflow docs](https://www.tensorflow.org/api_docs/python/tf/keras/Model#predict) indicate the two methods are functionally equivalent, but `__call__` is more efficient when operating inside a loop with smaller batches of input data.

Profiling the code with and without this change shows a ~25x speedup on calls to `calc_lc`.