### PR TITLE
add filter check in ztf sampling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+
+
+
+svdmodels/Bu2019lm_lbol.pkl
+svdmodels/Bu2019lm_mag.pkl

--- a/nmma/em/injection.py
+++ b/nmma/em/injection.py
@@ -212,6 +212,8 @@ def create_light_curve_data(
         sim["mag_err"] = np.nan
 
         for filt, group in sim.groupby("passband"):
+            if filt not in args.filters.split(","):
+                continue
             data_per_filt = copy.deepcopy(data_original[filt])
             lc = interp1d(
                 data_per_filt[:, 0],
@@ -232,7 +234,6 @@ def create_light_curve_data(
 
         for filt, group in sim.groupby("passband"):
             if filt not in args.filters.split(","):
-                #print("Filter {} not in filters list".format(filt))
                 continue
             if ztf_uncertainties and filt in ["g", "r", "i"]:
                 mag_err = []

--- a/nmma/em/injection.py
+++ b/nmma/em/injection.py
@@ -29,7 +29,8 @@ def create_light_curve_data(
         lbol_ncoeff=args.injection_svd_lbol_ncoeff,
     )
 
-    bands = {1: "g", 2: "r", 3: "i"}
+    #bands = {1: "g", 2: "r", 3: "i"}
+    bands = {i+1: b for i, b in enumerate(args.filters.split(","))}
     inv_bands = {v: k for k, v in bands.items()}
 
     if ztf_sampling:
@@ -82,6 +83,8 @@ def create_light_curve_data(
                 args.filters.split(","), args.injection_detection_limit.split(",")
             )
         }
+    assert len(detection_limit) == len(args.filters.split(","))
+    
     seed = args.generation_seed
 
     np.random.seed(seed)
@@ -228,6 +231,9 @@ def create_light_curve_data(
             sim.loc[group.index, "mag_err"] = lc_err(group["mjd"].tolist())
 
         for filt, group in sim.groupby("passband"):
+            if filt not in args.filters.split(","):
+                #print("Filter {} not in filters list".format(filt))
+                continue
             if ztf_uncertainties and filt in ["g", "r", "i"]:
                 mag_err = []
                 for idx, row in group.iterrows():


### PR DESCRIPTION
In injection.py, checks to see if current filter in loop of ztf-sampling is in the filter arguments. if not, continues to next filter without sampling. Retains requirement that filter is either g,r, or i for ztf. Shouldn't alter any other behaviour.