### PR TITLE
Update of   ZTF and Rubin light curves detection files

### DIFF
--- a/doc/gwemopt_light_curves_detection.md
+++ b/doc/gwemopt_light_curves_detection.md
@@ -1,0 +1,81 @@
+# Instructions for using **[nmma]** and **[gwemopt]** to simulate KNe detection with ZTF and LSST 
+
+First of all we have to install **[nmma]**  and **[gwemopt]** together in the same environmment. 
+
+1 **- Install nmma**:
+
+Instructions For  `nmma` click here:  **[NMMA-installation]**
+
+2 **- Install gwemopt**:
+
+Instructions For  `gwemopt` click here:  **[gwemopt-installation]**
+
+
+3 **- Split Farah(GWTC-3) CBCs data in BNS and NSBH**
+
+In the injections.dat files outcome  **[observing-scenarios-simulations]**, the masses of the CBCs are masses observed in the detectors. To splitting them  into BNS, NSBH and BBH populations, we should convert them in source frame mass. 
+
+All CBCs in ``Farah(GWTC-3)`` distribustion  that passed the SNR are recorded here: **[obs-scenarios-data-2022]** . For reasons of weight, we keep only the data necessary to produce the light curves, so the simulation with nmma.
+For more data like skymaps file please go to **[zenodo]**. Anyway we need to download it if we need to get skymap files (``.fits`` files )  to run the KNe  detection process with **[gwemopt]**.  
+
+Use the following python code for the ``split``: 
+
+Click here: **[split_CBC_data_for_nmma.py]**
+
+## **Generate a `simulation set`**
+
+4 **- Then use ``BNS`` or ``NSBH``**  injections.dat  to create injection file with nmma. 
+
+To generate a json file (``injection.json``)  with the BILBY processing of compact binary merging events. This injection contents a simulation set of parameters : luminosity_distance, log10_mej_wind, KNphi, inclination_EM, KNtimeshift, geocent_time for the KNe (`Bu2019lm` - BNS or `Bu2019nsbh` - NSBH) model.
+
+**`BNS` type**
+
+    nmma_create_injection --prior-file ./priors/Bu2019lm.prior --injection-file ./injections.dat --eos-file  ./example_files/eos/ALF2.dat --binary-type BNS --original-parameters --extension json --aligned-spin --binary-type BNS --filename ./outdir_BNS/Bu2019lm_injection
+
+**`NSBH` type**
+
+    nmma_create_injection --prior-file ./priors/Bu2019nsbh.prior --injection-file ./injections.dat --eos-file  ./example_files/eos/ALF2.dat --binary-type NSBH  --original-parameters --extension json --aligned-spin --filename ./outdir_NSBH/Bu2019nsbh_injection
+
+5 **- Generate lightcurve **
+
+This command line concern the ``ZTF`` for ``Rubin`` please replace `--injection-detection-limit 24.1,21.7,21.4,20.9,24.5,23.0,23.2,22.6,22.6 `` by  **--injection-detection-limit 23.9,25.0,24.7,24.0,23.3,22.1,23.2,22.6,22.6**
+
+**`BNS`**
+
+    light_curve_generation --model  Bu2019lm --svd-path ./svdmodels --outdir ./outdir_BNS --label injection_Bu2019lm --dt 0.5 --injection ./outdir_BNS/injection_Bu2019lm.json --injection-detection-limit 24.1,21.7,21.4,20.9,24.5,23.0,23.2,22.6,22.6 --filters u,g,r,i,z,y,J,H,K  --absolute --plot --generation-seed 42 
+
+**`NSBH`**
+
+
+light_curve_generation --model  Bu2019lm --svd-path ./svdmodels --outdir ./outdir_NSBH --label injection_Bu2019nsbh --dt 0.5 --injection ./outdir_NSBH/injection_Bu2019nsbh.json --injection-detection-limit 24.1,21.7,21.4,20.9,24.5,23.0,23.2,22.6,22.6 --filters u,g,r,i,z,y,J,H,K --absolute --plot --generation-seed 42 
+
+6 **- KNe detection process using ``gwemopt``**
+
+
+* Here we need to use ``skymap`` files from **[zenodo]**  in this example we use  **O4** (``--skymap-dir ./runs/O4/farah/allsky``), but this should be replace by **O5** if you work with **O5** data, then...
+* Then the json injection file ``injection_Bu2019lm.json`` for BNS or ``injection_Bu2019nsbh.json`` for NSBH, which contains the IDs of the simulations we need to identify their correspondence in the ``skymap`` data. 
+* And the direction of the ``config`` foder in  **[gwemopt]** file.
+
+* in **``--telescope ZTF``**, **ZTF** should be replace by ``LSST`` for ``Rubin`` telescope. 
+* Also the ``--exposuretime 300`` means time of observation (300 secondes), but we should also use ``--exposuretime 180` for 180 secondes.
+
+**`BNS`**
+
+    light_curve_detection --configDirectory ./gwemopt/config --outdir ./ztf_detection/outdir_BNS --injection-file  ./outdir_BNS/injection_Bu2019lm.json  --skymap-dir ./runs/O4/farah/allsky --lightcurve-dir ./outdir_BNS --binary-type BNS --filters u,g,r,i,z,y,J,H,K --exposuretime 300 --detections-file ./ztf_detection/bns_lc_skymap_detection.txt --telescope ZTF --tmin 0 --tmax 14 --dt 0.5  --parallel --number-of-cores 10 --generation-seed 42
+
+**`NSBH`**
+
+    light_curve_detection --configDirectory ./gwemopt/config --outdir ./ztf_detection/outdir_NSBH --injection-file  ./outdir_NSBH/injection_Bu2019nsbh.json  --skymap-dir ./runs/O4/farah/allsky --lightcurve-dir ./outdir_NSBH --binary-type NSBH --filters u,g,r,i,z,y,J,H,K --exposuretime 300 --detections-file ./ztf_detection/nsbh_lc_skymap_detection.txt --telescope ZTF --tmin 0 --tmax 14 --dt 0.5  --parallel --number-of-cores 10 --generation-seed 42
+
+
+
+
+
+[nmma]: https://github.com/nuclear-multimessenger-astronomy/nmma
+[NMMA-installation]: https://github.com/nuclear-multimessenger-astronomy/nmma/blob/main/doc/installation.md
+[gwemopt]: https://github.com/mcoughlin/gwemopt
+[gwemopt-installation]:https://github.com/mcoughlin/gwemopt/blob/main/README.md
+[observing-scenarios-simulations]:https://github.com/lpsinger/observing-scenarios-simulations
+[zenodo]:https://doi.org/10.5281/zenodo.7026209
+[obs-scenarios-data-2022]:https://github.com/weizmannk/obs-scenarios-data-2022
+[split_CBC_data_for_nmma.py]:https://github.com/weizmannk/obs-scenarios-data-2022/blob/main/split_CBC_data_for_nmma.py

--- a/nmma/em/create_lightcurves.py
+++ b/nmma/em/create_lightcurves.py
@@ -325,11 +325,15 @@ def main():
                 light_curve_model=light_curve_model,
             )
             print("Injection generated")
-            
+
+        try:
             fid = open(injection_outfile, "w")
+            # fid.write('# t[days] u g r i z y J H K\n')
+            # fid.write(str(" ".join(('# t[days]'," ".join(args.filters.split(',')),"\n"))))
             fid.write("# t[days] ")
             fid.write(str(" ".join(args.filters.split(","))))
             fid.write("\n")
+
             for ii, tt in enumerate(sample_times):
                 fid.write("%.5f " % sample_times[ii])
                 for filt in data.keys():
@@ -339,7 +343,13 @@ def main():
                     fid.write("%.3f " % data[filt][ii, 1])
                 fid.write("\n")
             fid.close()
-
+            
+        except IndexError:
+            print('\n===================================================================') 
+            print('Sorry we could not use ZTF or Rubin flags to generate those statistics\n')
+            print('Please remove all flags rely on with ZTF or Rubin then retry again')
+            print('===================================================================\n')
+            exit()
             mag_ds[index] = np.loadtxt(injection_outfile)
             
         if args.plot:

--- a/nmma/em/create_lightcurves.py
+++ b/nmma/em/create_lightcurves.py
@@ -200,106 +200,97 @@ def main():
     seed = args.generation_seed
     np.random.seed(seed)
 
-    if args.ztf_sampling or args.ztf_ToO or args.rubin_ToO:
-        
-        print('\n===================================================================') 
-        print('Sorry we could not use ZTF or  flags to generate those statistics')
-        print('===================================================================')
-        print('Please remove all flags rely on with ZTF or Rubin then retry again')
-        print('===================================================================\n')
-              
-    else:
-        bilby.core.utils.setup_logger(outdir=args.outdir, label=args.label)
-        bilby.core.utils.check_directory_exists_and_if_not_mkdir(args.outdir)
-        # initialize light curve model
-        sample_times = np.arange(args.tmin, args.tmax + args.dt, args.dt)
+    bilby.core.utils.setup_logger(outdir=args.outdir, label=args.label)
+    bilby.core.utils.check_directory_exists_and_if_not_mkdir(args.outdir)
+    # initialize light curve model
+    sample_times = np.arange(args.tmin, args.tmax + args.dt, args.dt)
 
-        if args.joint_light_curve:
+    if args.joint_light_curve:
 
-            assert args.model != "TrPi2018", "TrPi2018 is not a kilonova / supernova model"
+        assert args.model != "TrPi2018", "TrPi2018 is not a kilonova / supernova model"
 
-            if args.model != "nugent-hyper" or args.model != "salt2":
+        if args.model != "nugent-hyper" or args.model != "salt2":
 
-                kilonova_kwargs = dict(
-                    model=args.model,
-                    svd_path=args.svd_path,
-                    mag_ncoeff=args.svd_mag_ncoeff,
-                    lbol_ncoeff=args.svd_lbol_ncoeff,
-                    interpolation_type=args.interpolation_type,
-                    parameter_conversion=None,
-                )
+            kilonova_kwargs = dict(
+                model=args.model,
+                svd_path=args.svd_path,
+                mag_ncoeff=args.svd_mag_ncoeff,
+                lbol_ncoeff=args.svd_lbol_ncoeff,
+                interpolation_type=args.interpolation_type,
+                parameter_conversion=None,
+            )
 
-                light_curve_model = KilonovaGRBLightCurveModel(
-                    sample_times=sample_times,
-                    kilonova_kwargs=kilonova_kwargs,
-                    GRB_resolution=args.grb_resolution,
-                    jetType=args.jet_type,
-                )
-
-            else:
-
-                light_curve_model = SupernovaGRBLightCurveModel(
-                    sample_times=sample_times,
-                    GRB_resolution=args.grb_resolution,
-                    SNmodel=args.model,
-                    jetType=args.jet_type,
-                )
+            light_curve_model = KilonovaGRBLightCurveModel(
+                sample_times=sample_times,
+                kilonova_kwargs=kilonova_kwargs,
+                GRB_resolution=args.grb_resolution,
+                jetType=args.jet_type,
+            )
 
         else:
-            if args.model == "TrPi2018":
-                light_curve_model = GRBLightCurveModel(
-                    sample_times=sample_times,
-                    resolution=args.grb_resolution,
-                    jetType=args.jet_type,
-                )
-            elif args.model == "nugent-hyper" or args.model == "salt2":
-                light_curve_model = SupernovaLightCurveModel(
-                    sample_times=sample_times, model=args.model
-                )
 
-            else:
-                light_curve_kwargs = dict(
-                    model=args.model,
-                    sample_times=sample_times,
-                    svd_path=args.svd_path,
-                    mag_ncoeff=args.svd_mag_ncoeff,
-                    lbol_ncoeff=args.svd_lbol_ncoeff,
-                    interpolation_type=args.interpolation_type,
-                )
-                light_curve_model = SVDLightCurveModel(**light_curve_kwargs)
+            light_curve_model = SupernovaGRBLightCurveModel(
+                sample_times=sample_times,
+                GRB_resolution=args.grb_resolution,
+                SNmodel=args.model,
+                jetType=args.jet_type,
+            )
+
+    else:
+        if args.model == "TrPi2018":
+            light_curve_model = GRBLightCurveModel(
+                sample_times=sample_times,
+                resolution=args.grb_resolution,
+                jetType=args.jet_type,
+            )
+        elif args.model == "nugent-hyper" or args.model == "salt2":
+            light_curve_model = SupernovaLightCurveModel(
+                sample_times=sample_times, model=args.model
+            )
+
+        else:
+            light_curve_kwargs = dict(
+                model=args.model,
+                sample_times=sample_times,
+                svd_path=args.svd_path,
+                mag_ncoeff=args.svd_mag_ncoeff,
+                lbol_ncoeff=args.svd_lbol_ncoeff,
+                interpolation_type=args.interpolation_type,
+            )
+            light_curve_model = SVDLightCurveModel(**light_curve_kwargs)
+    
+    ## read injection file 
+    with open(args.injection, "r") as f:
+        injection_dict = json.load(f, object_hook=bilby.core.utils.decode_bilby_json)
+
+    args.kilonova_tmin = args.tmin
+    args.kilonova_tmax = args.tmax
+    args.kilonova_tstep = args.dt
+
+    args.kilonova_injection_model = args.model
+    args.kilonova_injection_svd = args.svd_path
+    args.injection_svd_mag_ncoeff = args.svd_mag_ncoeff
+    args.injection_svd_lbol_ncoeff = args.svd_lbol_ncoeff
+
+    # args.injection_detection_limit = np.inf
+    args.kilonova_error = 0
+
+    injection_df = injection_dict["injections"]
+    
+    # save simulation_id from observing scenarios data
+    # we save lighcurve for each event with its initial simulation ID
+    # from observing scenarios 
+    simulation_id = injection_df['simulation_id']
+    
+    mag_ds = {}
+    for index, row in injection_df.iterrows():
         
-        ## read injection file 
-        with open(args.injection, "r") as f:
-            injection_dict = json.load(f, object_hook=bilby.core.utils.decode_bilby_json)
-
-        args.kilonova_tmin = args.tmin
-        args.kilonova_tmax = args.tmax
-        args.kilonova_tstep = args.dt
-
-        args.kilonova_injection_model = args.model
-        args.kilonova_injection_svd = args.svd_path
-        args.injection_svd_mag_ncoeff = args.svd_mag_ncoeff
-        args.injection_svd_lbol_ncoeff = args.svd_lbol_ncoeff
-
-        # args.injection_detection_limit = np.inf
-        args.kilonova_error = 0
-
-        injection_df = injection_dict["injections"]
-        
-        # save simulation_id from observing scenarios data
-        # we save lighcurve for each event with its initial simulation ID
-        # from observing scenarios 
-        simulation_id = injection_df['simulation_id']
-        
-        mag_ds = {}
-        for index, row in injection_df.iterrows():
-            
-            injection_outfile = os.path.join(args.outdir, "%d.dat" % simulation_id[index])
-            if os.path.isfile(injection_outfile):
+        injection_outfile = os.path.join(args.outdir, "%d.dat" % simulation_id[index])
+        if os.path.isfile(injection_outfile):
             try:
                 mag_ds[index] = np.loadtxt(injection_outfile)
                 continue
-                
+            
             except ValueError :
                 print('\n===================================================================') 
                 print('The previous run generated light curves with unreadable content.\n')
@@ -307,24 +298,23 @@ def main():
                 print('===================================================================\n')
                 exit()
 
+        injection_parameters = row.to_dict()
 
-            injection_parameters = row.to_dict()
+        try:
+            tc_gps = time.Time(injection_parameters["geocent_time_x"], format="gps")
+        except KeyError:
+            tc_gps = time.Time(injection_parameters["geocent_time"], format="gps")
+        trigger_time = tc_gps.mjd
 
-            try:
-                tc_gps = time.Time(injection_parameters["geocent_time_x"], format="gps")
-            except KeyError:
-                tc_gps = time.Time(injection_parameters["geocent_time"], format="gps")
-            trigger_time = tc_gps.mjd
+        injection_parameters["kilonova_trigger_time"] = trigger_time
 
-            injection_parameters["kilonova_trigger_time"] = trigger_time
-
-            data = create_light_curve_data(
-                injection_parameters,
-                args,
-                doAbsolute=args.absolute,
-                light_curve_model=light_curve_model,
-            )
-            print("Injection generated")
+        data = create_light_curve_data(
+            injection_parameters,
+            args,
+            doAbsolute=args.absolute,
+            light_curve_model=light_curve_model,
+        )
+        print("Injection generated")
 
         try:
             fid = open(injection_outfile, "w")
@@ -350,90 +340,91 @@ def main():
             print('Please remove all flags rely on with ZTF or Rubin then retry again')
             print('===================================================================\n')
             exit()
-            mag_ds[index] = np.loadtxt(injection_outfile)
+        
+    mag_ds[index] = np.loadtxt(injection_outfile)
+        
+    if args.plot:
+        import matplotlib.pyplot as plt
+        import matplotlib
+        matplotlib.use("agg")
+        params = {
+            "backend": "pdf",
+            "axes.labelsize": 42,
+            "legend.fontsize": 42,
+            "xtick.labelsize": 42,
+            "ytick.labelsize": 42,
+            "text.usetex": True,
+            "font.family": "Times New Roman",
+            "figure.figsize": [16, 20],
+        }
+        matplotlib.rcParams.update(params)
+
+        plotName = os.path.join(
+            args.outdir, "injection_" + args.model + "_lightcurves.pdf"
+        )
+        
+        fig = plt.figure()
+        
+        filts = args.filters.split(",")
+        #filts = "u,g,r,i,z,y,J,H,K".split(",")
+        ncols = 1
+        nrows = int(np.ceil(len(filts) / ncols))
+        gs = fig.add_gridspec(nrows=nrows, ncols=ncols, wspace=0.6, hspace=0.5)
+
+        for ii, filt in enumerate(filts):
+            loc_x, loc_y = np.divmod(ii, nrows)
+            loc_x, loc_y = int(loc_x), int(loc_y)
+            ax = fig.add_subplot(gs[loc_y, loc_x])
+
+            data_out = []
+            for jj, key in enumerate(list(mag_ds.keys())):
+                data_out.append(mag_ds[key][:, ii + 1])
+            data_out = np.vstack(data_out)
+
+            bins = np.linspace(-20, 1, 50)
+
+            def return_hist(x):
+                hist, bin_edges = np.histogram(x, bins=bins)
+                return hist
+
+            hist = np.apply_along_axis(lambda x: return_hist(x), -1, data_out.T)
+            bins = (bins[1:] + bins[:-1]) / 2.0
+
+            X, Y = np.meshgrid(sample_times, bins)
+            hist = hist.astype(np.float64)
+            hist[hist == 0.0] = np.nan
+
+            c= ax.pcolormesh(X, Y, hist.T, shading="auto", cmap="cividis", alpha=0.7)
+
+            # plot 10th, 50th, 90th percentiles
+            ax.plot(sample_times, np.nanpercentile(data_out, 50, axis=0), "k--")
+            ax.plot(sample_times, np.nanpercentile(data_out, 90, axis=0), "k--")
+            ax.plot(sample_times, np.nanpercentile(data_out, 10, axis=0), "k--")
+
+            ax.set_xlim([0, 14])
+            ax.set_ylim([-12, -18])
+            ax.set_ylabel(filt, fontsize=30, rotation=0, labelpad=14)
+
+            if ii == len(filts) - 1:
+                ax.set_xticks([0, 2, 4, 6, 8, 10, 12, 14])
+            else:
+                plt.setp(ax.get_xticklabels(), visible=False)
+            ax.set_yticks([-18, -16, -14, -12])
+            ax.tick_params(axis="x", labelsize=42)
+            ax.tick_params(axis="y", labelsize=42)
+            ax.grid(which="both", alpha=0.5)
             
-        if args.plot:
-            import matplotlib.pyplot as plt
-            import matplotlib
-            matplotlib.use("agg")
-            params = {
-                "backend": "pdf",
-                "axes.labelsize": 42,
-                "legend.fontsize": 42,
-                "xtick.labelsize": 42,
-                "ytick.labelsize": 42,
-                "text.usetex": True,
-                "font.family": "Times New Roman",
-                "figure.figsize": [16, 20],
-            }
-            matplotlib.rcParams.update(params)
+        fig.colorbar(c, ax = ax)
+        fig.text(0.4, 0.05, r"Time [days]", fontsize=42)
+        fig.text(
+            0.01,
+            0.5,
+            r"Absolute Magnitude",
+            va="center",
+            rotation="vertical",
+            fontsize=42,
+        )
 
-            plotName = os.path.join(
-                args.outdir, "injection_" + args.model + "_lightcurves.pdf"
-            )
-            
-            fig = plt.figure()
-            
-            filts = args.filters.split(",")
-            #filts = "u,g,r,i,z,y,J,H,K".split(",")
-            ncols = 1
-            nrows = int(np.ceil(len(filts) / ncols))
-            gs = fig.add_gridspec(nrows=nrows, ncols=ncols, wspace=0.6, hspace=0.5)
-
-            for ii, filt in enumerate(filts):
-                loc_x, loc_y = np.divmod(ii, nrows)
-                loc_x, loc_y = int(loc_x), int(loc_y)
-                ax = fig.add_subplot(gs[loc_y, loc_x])
-
-                data_out = []
-                for jj, key in enumerate(list(mag_ds.keys())):
-                    data_out.append(mag_ds[key][:, ii + 1])
-                data_out = np.vstack(data_out)
-
-                bins = np.linspace(-20, 1, 50)
-
-                def return_hist(x):
-                    hist, bin_edges = np.histogram(x, bins=bins)
-                    return hist
-
-                hist = np.apply_along_axis(lambda x: return_hist(x), -1, data_out.T)
-                bins = (bins[1:] + bins[:-1]) / 2.0
-
-                X, Y = np.meshgrid(sample_times, bins)
-                hist = hist.astype(np.float64)
-                hist[hist == 0.0] = np.nan
-
-                c= ax.pcolormesh(X, Y, hist.T, shading="auto", cmap="cividis", alpha=0.7)
-
-                # plot 10th, 50th, 90th percentiles
-                ax.plot(sample_times, np.nanpercentile(data_out, 50, axis=0), "k--")
-                ax.plot(sample_times, np.nanpercentile(data_out, 90, axis=0), "k--")
-                ax.plot(sample_times, np.nanpercentile(data_out, 10, axis=0), "k--")
-
-                ax.set_xlim([0, 14])
-                ax.set_ylim([-12, -18])
-                ax.set_ylabel(filt, fontsize=30, rotation=0, labelpad=14)
-
-                if ii == len(filts) - 1:
-                    ax.set_xticks([0, 2, 4, 6, 8, 10, 12, 14])
-                else:
-                    plt.setp(ax.get_xticklabels(), visible=False)
-                ax.set_yticks([-18, -16, -14, -12])
-                ax.tick_params(axis="x", labelsize=42)
-                ax.tick_params(axis="y", labelsize=42)
-                ax.grid(which="both", alpha=0.5)
-                
-            fig.colorbar(c, ax = ax)
-            fig.text(0.4, 0.05, r"Time [days]", fontsize=42)
-            fig.text(
-                0.01,
-                0.5,
-                r"Absolute Magnitude",
-                va="center",
-                rotation="vertical",
-                fontsize=42,
-            )
-
-            #plt.tight_layout()
-            plt.savefig(plotName, bbox_inches="tight")
-            plt.close()
+        #plt.tight_layout()
+        plt.savefig(plotName, bbox_inches="tight")
+        plt.close()

--- a/nmma/em/create_lightcurves.py
+++ b/nmma/em/create_lightcurves.py
@@ -296,8 +296,17 @@ def main():
             
             injection_outfile = os.path.join(args.outdir, "%d.dat" % simulation_id[index])
             if os.path.isfile(injection_outfile):
+            try:
                 mag_ds[index] = np.loadtxt(injection_outfile)
                 continue
+                
+            except ValueError :
+                print('\n===================================================================') 
+                print('The previous run generated light curves with unreadable content.\n')
+                print('Please remove all output files in .dat format then retry.')
+                print('===================================================================\n')
+                exit()
+
 
             injection_parameters = row.to_dict()
 

--- a/nmma/em/create_lightcurves.py
+++ b/nmma/em/create_lightcurves.py
@@ -2,7 +2,6 @@ import os
 import numpy as np
 import argparse
 import json
-from scipy.interpolate import interpolate as interp
 
 from astropy import time
 
@@ -16,8 +15,6 @@ from .model import (
     KilonovaGRBLightCurveModel,
 )
 from .injection import create_light_curve_data
-from .utils import NumpyEncoder, check_default_attr
-
 
 def main():
 
@@ -25,17 +22,29 @@ def main():
         description="Inference on kilonova ejecta parameters."
     )
     parser.add_argument(
-        "--model", type=str, required=True, help="Name of the kilonova model to be used"
+        "--model", 
+        type=str, 
+        required=True, 
+        help="Name of the kilonova model to be used"
     )
     parser.add_argument(
         "--svd-path",
         type=str,
+        default="svdmodels",
         help="Path to the SVD directory, with {model}_mag.pkl and {model}_lbol.pkl",
     )
     parser.add_argument(
-        "--outdir", type=str, required=True, help="Path to the output directory"
+        "--outdir", 
+        type=str, 
+        required=True, 
+        help="Path to the output directory"
     )
-    parser.add_argument("--label", type=str, required=True, help="Label for the run")
+    parser.add_argument(
+        "--label", 
+        type=str, 
+        required=True, 
+        help="Label for the run"
+    )
     parser.add_argument(
         "--tmin",
         type=float,
@@ -49,7 +58,10 @@ def main():
         help="Days to be stoped analysing from the trigger time (default: 14)",
     )
     parser.add_argument(
-        "--dt", type=float, default=0.1, help="Time step in day (default: 0.1)"
+        "--dt", 
+        type=float, 
+        default=0.1, 
+        help="Time step in day (default: 0.1)"
     )
     parser.add_argument(
         "--svd-mag-ncoeff",
@@ -70,18 +82,6 @@ def main():
         default="u,g,r,i,z,y,J,H,K",
     )
     parser.add_argument(
-        "--grb-resolution",
-        type=float,
-        default=5,
-        help="The upper bound on the ratio between thetaWing and thetaCore (default: 5)",
-    )
-    parser.add_argument(
-        "--jet-type",
-        type=int,
-        default=0,
-        help="Jet type to used used for GRB afterglow light curve (default: 0)",
-    )
-    parser.add_argument(
         "--generation-seed",
         metavar="seed",
         type=int,
@@ -89,7 +89,10 @@ def main():
         help="Injection generation seed (default: 42)",
     )
     parser.add_argument(
-        "--injection", metavar="PATH", type=str, help="Path to the injection json file"
+        "--injection", 
+        metavar="PATH", 
+        type=str, 
+        help="Path to the injection json file"
     )
     parser.add_argument(
         "--joint-light-curve",
@@ -102,7 +105,10 @@ def main():
         action="store_true",
     )
     parser.add_argument(
-        "--plot", action="store_true", default=False, help="add best fit plot"
+        "--plot", 
+        action="store_true", 
+        default=False, 
+        help="add best fit plot"
     )
     parser.add_argument(
         "--verbose",
@@ -124,10 +130,15 @@ def main():
         default="sklearn_gp",
     )
     parser.add_argument(
-        "--absolute", action="store_true", default=False, help="Absolute Magnitude"
+        "--absolute", 
+        action="store_true", 
+        default=False, 
+        help="Absolute Magnitude"
     )
     parser.add_argument(
-        "--ztf-sampling", help="Use realistic ZTF sampling", action="store_true"
+        "--ztf-sampling", 
+        help="Use realistic ZTF sampling", 
+        action="store_true"
     )
     parser.add_argument(
         "--ztf-uncertainties",
@@ -189,212 +200,221 @@ def main():
     seed = args.generation_seed
     np.random.seed(seed)
 
-    bilby.core.utils.setup_logger(outdir=args.outdir, label=args.label)
-    bilby.core.utils.check_directory_exists_and_if_not_mkdir(args.outdir)
-
-    # initialize light curve model
-    sample_times = np.arange(args.tmin, args.tmax + args.dt, args.dt)
-
-    if args.joint_light_curve:
-
-        assert args.model != "TrPi2018", "TrPi2018 is not a kilonova / supernova model"
-
-        if args.model != "nugent-hyper" or args.model != "salt2":
-
-            kilonova_kwargs = dict(
-                model=args.model,
-                svd_path=args.svd_path,
-                mag_ncoeff=args.svd_mag_ncoeff,
-                lbol_ncoeff=args.svd_lbol_ncoeff,
-                interpolation_type=args.interpolation_type,
-                parameter_conversion=None,
-            )
-
-            light_curve_model = KilonovaGRBLightCurveModel(
-                sample_times=sample_times,
-                kilonova_kwargs=kilonova_kwargs,
-                GRB_resolution=args.grb_resolution,
-                jetType=args.jet_type,
-            )
-
-        else:
-
-            light_curve_model = SupernovaGRBLightCurveModel(
-                sample_times=sample_times,
-                GRB_resolution=args.grb_resolution,
-                SNmodel=args.model,
-                jetType=args.jet_type,
-            )
-
+    if args.ztf_sampling or args.ztf_ToO or args.rubin_ToO:
+        
+        print('\n===================================================================') 
+        print('Sorry we could not use ZTF or  flags to generate those statistics')
+        print('===================================================================')
+        print('Please remove all flags rely on with ZTF or Rubin then retry again')
+        print('===================================================================\n')
+              
     else:
-        if args.model == "TrPi2018":
-            light_curve_model = GRBLightCurveModel(
-                sample_times=sample_times,
-                resolution=args.grb_resolution,
-                jetType=args.jet_type,
-            )
-        elif args.model == "nugent-hyper" or args.model == "salt2":
-            light_curve_model = SupernovaLightCurveModel(
-                sample_times=sample_times, model=args.model
-            )
+        bilby.core.utils.setup_logger(outdir=args.outdir, label=args.label)
+        bilby.core.utils.check_directory_exists_and_if_not_mkdir(args.outdir)
+        # initialize light curve model
+        sample_times = np.arange(args.tmin, args.tmax + args.dt, args.dt)
+
+        if args.joint_light_curve:
+
+            assert args.model != "TrPi2018", "TrPi2018 is not a kilonova / supernova model"
+
+            if args.model != "nugent-hyper" or args.model != "salt2":
+
+                kilonova_kwargs = dict(
+                    model=args.model,
+                    svd_path=args.svd_path,
+                    mag_ncoeff=args.svd_mag_ncoeff,
+                    lbol_ncoeff=args.svd_lbol_ncoeff,
+                    interpolation_type=args.interpolation_type,
+                    parameter_conversion=None,
+                )
+
+                light_curve_model = KilonovaGRBLightCurveModel(
+                    sample_times=sample_times,
+                    kilonova_kwargs=kilonova_kwargs,
+                    GRB_resolution=args.grb_resolution,
+                    jetType=args.jet_type,
+                )
+
+            else:
+
+                light_curve_model = SupernovaGRBLightCurveModel(
+                    sample_times=sample_times,
+                    GRB_resolution=args.grb_resolution,
+                    SNmodel=args.model,
+                    jetType=args.jet_type,
+                )
 
         else:
-            light_curve_kwargs = dict(
-                model=args.model,
-                sample_times=sample_times,
-                svd_path=args.svd_path,
-                mag_ncoeff=args.svd_mag_ncoeff,
-                lbol_ncoeff=args.svd_lbol_ncoeff,
-                interpolation_type=args.interpolation_type,
-            )
-            light_curve_model = SVDLightCurveModel(**light_curve_kwargs)
+            if args.model == "TrPi2018":
+                light_curve_model = GRBLightCurveModel(
+                    sample_times=sample_times,
+                    resolution=args.grb_resolution,
+                    jetType=args.jet_type,
+                )
+            elif args.model == "nugent-hyper" or args.model == "salt2":
+                light_curve_model = SupernovaLightCurveModel(
+                    sample_times=sample_times, model=args.model
+                )
 
-    with open(args.injection, "r") as f:
-        injection_dict = json.load(f, object_hook=bilby.core.utils.decode_bilby_json)
-
-    args.kilonova_tmin = args.tmin
-    args.kilonova_tmax = args.tmax
-    args.kilonova_tstep = args.dt
-
-    args.kilonova_injection_model = args.model
-    args.kilonova_injection_svd = args.svd_path
-    args.injection_svd_mag_ncoeff = args.svd_mag_ncoeff
-    args.injection_svd_lbol_ncoeff = args.svd_lbol_ncoeff
-
-    # args.injection_detection_limit = np.inf
-    args.kilonova_error = 0
-
-    injection_df = injection_dict["injections"]
-    mag_ds = {}
-    for index, row in injection_df.iterrows():
-
-        injection_outfile = os.path.join(args.outdir, "%d.dat" % index)
-        if os.path.isfile(injection_outfile):
-            with open(injection_outfile, "r") as outfile:
-                mag_ds[index] = json.loads(outfile.read())
-            continue
-
-        injection_parameters = row.to_dict()
-
-        try:
-            tc_gps = time.Time(injection_parameters["geocent_time_x"], format="gps")
-        except KeyError:
-            tc_gps = time.Time(injection_parameters["geocent_time"], format="gps")
-        trigger_time = tc_gps.mjd
-
-        injection_parameters["kilonova_trigger_time"] = trigger_time
-
-        data = create_light_curve_data(
-            injection_parameters,
-            args,
-            doAbsolute=args.absolute,
-            light_curve_model=light_curve_model,
-        )
-        print("Injection generated")
-
-        with open(injection_outfile, "w") as outfile:
-            json.dump(data, outfile, cls=NumpyEncoder)
-
-        mag_ds[index] = data
-
-    if args.plot:
-        import matplotlib.pyplot as plt
-        import matplotlib
-
-        params = {
-            "backend": "pdf",
-            "axes.labelsize": 30,
-            "legend.fontsize": 30,
-            "xtick.labelsize": 24,
-            "ytick.labelsize": 24,
-            "text.usetex": True,
-            "font.family": "Times New Roman",
-            "figure.figsize": [16, 20],
-        }
-        matplotlib.rcParams.update(params)
-
-        ztf_sampling = check_default_attr(args, "ztf_sampling")
-        ztf_ToO = check_default_attr(args, "ztf_ToO")
-        rubin_ToO = check_default_attr(args, "rubin_ToO")
-        photometry_augmentation = check_default_attr(
-            args, "photometry_augmentation", default=None
-        )
-
-        plotName = os.path.join(
-            args.outdir, "injection_" + args.model + "_lightcurves.pdf"
-        )
-        fig = plt.figure(figsize=(16, 18))
-
-        filts = args.filters.split(",")
-        ncols = 1
-        nrows = int(np.ceil(len(filts) / ncols))
-        gs = fig.add_gridspec(nrows=nrows, ncols=ncols, wspace=0.6, hspace=0.5)
-
-        for ii, filt in enumerate(filts):
-            loc_x, loc_y = np.divmod(ii, nrows)
-            loc_x, loc_y = int(loc_x), int(loc_y)
-            ax = fig.add_subplot(gs[loc_y, loc_x])
-
-            data_out = []
-            for jj, key in enumerate(list(mag_ds.keys())):
-                data_set = np.array(mag_ds[key][filt])
-                if ztf_sampling or ztf_ToO or rubin_ToO or photometry_augmentation:
-                    f = interp.interp1d(
-                        data_set[:, 0], data_set[:, 1], fill_value="extrapolate"
-                    )
-                    data_out.append(f(sample_times))
-                else:
-                    data_out.append(data_set[:, 1])
-            data_out = np.vstack(data_out)
-
-            bins = np.linspace(-20, 1, 50)
-
-            def return_hist(x):
-                hist, bin_edges = np.histogram(x, bins=bins)
-                return hist
-
-            hist = np.apply_along_axis(lambda x: return_hist(x), -1, data_out.T)
-            bins = (bins[1:] + bins[:-1]) / 2.0
-
-            X, Y = np.meshgrid(sample_times, bins)
-            hist = hist.astype(np.float64)
-            hist[hist == 0.0] = np.nan
-
-            ax.pcolormesh(X, Y, hist.T, shading="auto", cmap="viridis", alpha=0.7)
-
-            # plot 10th, 50th, 90th percentiles
-            ax.plot(
-                sample_times,
-                np.nanpercentile(data_out, 50, axis=0),
-                c="k",
-                linestyle="--",
-            )
-            ax.plot(sample_times, np.nanpercentile(data_out, 90, axis=0), "k--")
-            ax.plot(sample_times, np.nanpercentile(data_out, 10, axis=0), "k--")
-
-            ax.set_xlim([0, 14])
-            ax.set_ylim([-12, -18])
-            ax.set_ylabel(filt, fontsize=30, rotation=0, labelpad=14)
-
-            if ii == len(filts) - 1:
-                ax.set_xticks([0, 2, 4, 6, 8, 10, 12, 14])
             else:
-                plt.setp(ax.get_xticklabels(), visible=False)
-            ax.set_yticks([-18, -16, -14, -12])
-            ax.tick_params(axis="x", labelsize=30)
-            ax.tick_params(axis="y", labelsize=30)
-            ax.grid(which="both", alpha=0.5)
+                light_curve_kwargs = dict(
+                    model=args.model,
+                    sample_times=sample_times,
+                    svd_path=args.svd_path,
+                    mag_ncoeff=args.svd_mag_ncoeff,
+                    lbol_ncoeff=args.svd_lbol_ncoeff,
+                    interpolation_type=args.interpolation_type,
+                )
+                light_curve_model = SVDLightCurveModel(**light_curve_kwargs)
+        
+        ## read injection file 
+        with open(args.injection, "r") as f:
+            injection_dict = json.load(f, object_hook=bilby.core.utils.decode_bilby_json)
 
-        fig.text(0.45, 0.05, "Time [days]", fontsize=30)
-        fig.text(
-            0.01,
-            0.5,
-            "Absolute Magnitude",
-            va="center",
-            rotation="vertical",
-            fontsize=30,
-        )
+        args.kilonova_tmin = args.tmin
+        args.kilonova_tmax = args.tmax
+        args.kilonova_tstep = args.dt
 
-        # plt.tight_layout()
-        plt.savefig(plotName, bbox_inches="tight")
-        plt.close()
+        args.kilonova_injection_model = args.model
+        args.kilonova_injection_svd = args.svd_path
+        args.injection_svd_mag_ncoeff = args.svd_mag_ncoeff
+        args.injection_svd_lbol_ncoeff = args.svd_lbol_ncoeff
+
+        # args.injection_detection_limit = np.inf
+        args.kilonova_error = 0
+
+        injection_df = injection_dict["injections"]
+        
+        # save simulation_id from observing scenarios data
+        # we save lighcurve for each event with its initial simulation ID
+        # from observing scenarios 
+        simulation_id = injection_df['simulation_id']
+        
+        mag_ds = {}
+        for index, row in injection_df.iterrows():
+            
+            injection_outfile = os.path.join(args.outdir, "%d.dat" % simulation_id[index])
+            if os.path.isfile(injection_outfile):
+                mag_ds[index] = np.loadtxt(injection_outfile)
+                continue
+
+            injection_parameters = row.to_dict()
+
+            try:
+                tc_gps = time.Time(injection_parameters["geocent_time_x"], format="gps")
+            except KeyError:
+                tc_gps = time.Time(injection_parameters["geocent_time"], format="gps")
+            trigger_time = tc_gps.mjd
+
+            injection_parameters["kilonova_trigger_time"] = trigger_time
+
+            data = create_light_curve_data(
+                injection_parameters,
+                args,
+                doAbsolute=args.absolute,
+                light_curve_model=light_curve_model,
+            )
+            print("Injection generated")
+            
+            fid = open(injection_outfile, "w")
+            fid.write("# t[days] ")
+            fid.write(str(" ".join(args.filters.split(","))))
+            fid.write("\n")
+            for ii, tt in enumerate(sample_times):
+                fid.write("%.5f " % sample_times[ii])
+                for filt in data.keys():
+                    if args.filters:
+                        if filt not in args.filters.split(","):
+                            continue
+                    fid.write("%.3f " % data[filt][ii, 1])
+                fid.write("\n")
+            fid.close()
+
+            mag_ds[index] = np.loadtxt(injection_outfile)
+            
+        if args.plot:
+            import matplotlib.pyplot as plt
+            import matplotlib
+            matplotlib.use("agg")
+            params = {
+                "backend": "pdf",
+                "axes.labelsize": 42,
+                "legend.fontsize": 42,
+                "xtick.labelsize": 42,
+                "ytick.labelsize": 42,
+                "text.usetex": True,
+                "font.family": "Times New Roman",
+                "figure.figsize": [16, 20],
+            }
+            matplotlib.rcParams.update(params)
+
+            plotName = os.path.join(
+                args.outdir, "injection_" + args.model + "_lightcurves.pdf"
+            )
+            
+            fig = plt.figure()
+            
+            filts = args.filters.split(",")
+            #filts = "u,g,r,i,z,y,J,H,K".split(",")
+            ncols = 1
+            nrows = int(np.ceil(len(filts) / ncols))
+            gs = fig.add_gridspec(nrows=nrows, ncols=ncols, wspace=0.6, hspace=0.5)
+
+            for ii, filt in enumerate(filts):
+                loc_x, loc_y = np.divmod(ii, nrows)
+                loc_x, loc_y = int(loc_x), int(loc_y)
+                ax = fig.add_subplot(gs[loc_y, loc_x])
+
+                data_out = []
+                for jj, key in enumerate(list(mag_ds.keys())):
+                    data_out.append(mag_ds[key][:, ii + 1])
+                data_out = np.vstack(data_out)
+
+                bins = np.linspace(-20, 1, 50)
+
+                def return_hist(x):
+                    hist, bin_edges = np.histogram(x, bins=bins)
+                    return hist
+
+                hist = np.apply_along_axis(lambda x: return_hist(x), -1, data_out.T)
+                bins = (bins[1:] + bins[:-1]) / 2.0
+
+                X, Y = np.meshgrid(sample_times, bins)
+                hist = hist.astype(np.float64)
+                hist[hist == 0.0] = np.nan
+
+                c= ax.pcolormesh(X, Y, hist.T, shading="auto", cmap="cividis", alpha=0.7)
+
+                # plot 10th, 50th, 90th percentiles
+                ax.plot(sample_times, np.nanpercentile(data_out, 50, axis=0), "k--")
+                ax.plot(sample_times, np.nanpercentile(data_out, 90, axis=0), "k--")
+                ax.plot(sample_times, np.nanpercentile(data_out, 10, axis=0), "k--")
+
+                ax.set_xlim([0, 14])
+                ax.set_ylim([-12, -18])
+                ax.set_ylabel(filt, fontsize=30, rotation=0, labelpad=14)
+
+                if ii == len(filts) - 1:
+                    ax.set_xticks([0, 2, 4, 6, 8, 10, 12, 14])
+                else:
+                    plt.setp(ax.get_xticklabels(), visible=False)
+                ax.set_yticks([-18, -16, -14, -12])
+                ax.tick_params(axis="x", labelsize=42)
+                ax.tick_params(axis="y", labelsize=42)
+                ax.grid(which="both", alpha=0.5)
+                
+            fig.colorbar(c, ax = ax)
+            fig.text(0.4, 0.05, r"Time [days]", fontsize=42)
+            fig.text(
+                0.01,
+                0.5,
+                r"Absolute Magnitude",
+                va="center",
+                rotation="vertical",
+                fontsize=42,
+            )
+
+            #plt.tight_layout()
+            plt.savefig(plotName, bbox_inches="tight")
+            plt.close()

--- a/nmma/em/detect_lightcurves.py
+++ b/nmma/em/detect_lightcurves.py
@@ -212,7 +212,6 @@ def main():
         outdir = os.path.join(args.outdir, str(index))
         
         efffile = os.path.join(outdir, f"efficiency_true_{indices[index]}.txt")
-        #print(efffile)
         
         ## Choose band for the best proxy
         # for ZTF r-band give the best proxy 

--- a/nmma/em/detect_lightcurves.py
+++ b/nmma/em/detect_lightcurves.py
@@ -221,7 +221,6 @@ def main():
         else:
             absmag.append(np.min(lcs[index][:, 4]))
             
-        print(absmag)
         
         if not os.path.isfile(efffile):
             fid.write("0\n")

--- a/nmma/em/detect_lightcurves.py
+++ b/nmma/em/detect_lightcurves.py
@@ -270,7 +270,6 @@ def main():
     probs_miss = probs[idy]
 
     print( dataframe_from_detected["mass_1"], " :",dataframe_from_detected["mass_2"] )
-    print( dataframe_from_missed)
     (mchirp_det, eta_det, q_det) = ms2mc(
         dataframe_from_detected["mass_1"],
         dataframe_from_detected["mass_2"],

--- a/nmma/em/detect_lightcurves.py
+++ b/nmma/em/detect_lightcurves.py
@@ -155,7 +155,6 @@ def main():
     lcs = {}
     for index, row in dataframe_from_inj.iterrows():
         outdir = os.path.join(args.outdir, str(index))
-        #outdir = os.path.join('./obs_paper/detection_lc/outdir_BNS', str(index))
         if not os.path.isdir(outdir):
             os.makedirs(outdir)
  

--- a/nmma/em/detect_lightcurves.py
+++ b/nmma/em/detect_lightcurves.py
@@ -211,7 +211,6 @@ def main():
     #fid = open('lc_skymap_detection', "w")
     for index, row in dataframe_from_inj.iterrows():
         outdir = os.path.join(args.outdir, str(index))
-        #outdir = os.path.join('./obs_paper/detection_lc/outdir_BNS', str(index))
         
         efffile = os.path.join(outdir, f"efficiency_true_{indices[index]}.txt")
         #print(efffile)

--- a/nmma/em/detect_lightcurves.py
+++ b/nmma/em/detect_lightcurves.py
@@ -160,7 +160,6 @@ def main():
  
         skymap_file = os.path.join(args.skymap_dir, "%d.fits" % indices[index])
         lc_file = os.path.join(args.lightcurve_dir, "%d.dat" %  indices[index])
-
         
         # fixed scheduling time as observation plan
         #number_shot = int(1 + (args.tmax - args.tmin)/args.dt)
@@ -168,8 +167,6 @@ def main():
         #lcs[index] = np.loadtxt(lc_file)[0:number_shot,]
         
         lcs[index] = np.loadtxt(lc_file)
-        
-  
 
         efffile = os.path.join(outdir, f"efficiency_true_{indices[index]}.txt")
         if os.path.isfile(efffile):

--- a/nmma/em/detect_lightcurves.py
+++ b/nmma/em/detect_lightcurves.py
@@ -160,10 +160,9 @@ def main():
  
         skymap_file = os.path.join(args.skymap_dir, "%d.fits" % indices[index])
         lc_file = os.path.join(args.lightcurve_dir, "%d.dat" %  indices[index])
+
         
-        #lc_file = os.path.join('./obs_paper/absolute_mag_lc/outdir_BNS', "%d.dat" %  indices[index])
-        
-                # fixed scheduling time as observation plan
+        # fixed scheduling time as observation plan
         #number_shot = int(1 + (args.tmax - args.tmin)/args.dt)
         
         #lcs[index] = np.loadtxt(lc_file)[0:number_shot,]

--- a/nmma/em/detect_lightcurves.py
+++ b/nmma/em/detect_lightcurves.py
@@ -173,7 +173,6 @@ def main():
   
 
         efffile = os.path.join(outdir, f"efficiency_true_{indices[index]}.txt")
-        print(efffile)
         if os.path.isfile(efffile):
             continue
 

--- a/nmma/em/detect_lightcurves.py
+++ b/nmma/em/detect_lightcurves.py
@@ -262,7 +262,6 @@ def main():
     probs_det = probs[idx]
     probs_miss = probs[idy]
 
-    print( dataframe_from_detected["mass_1"], " :",dataframe_from_detected["mass_2"] )
     (mchirp_det, eta_det, q_det) = ms2mc(
         dataframe_from_detected["mass_1"],
         dataframe_from_detected["mass_2"],

--- a/nmma/em/detect_lightcurves.py
+++ b/nmma/em/detect_lightcurves.py
@@ -162,7 +162,6 @@ def main():
         skymap_file = os.path.join(args.skymap_dir, "%d.fits" % indices[index])
         lc_file = os.path.join(args.lightcurve_dir, "%d.dat" %  indices[index])
         
-        #skymap_file = os.path.join('~/OBSERVING_SCENARIOS/runs/O4/farah/allsky', "%d.fits" % indices[index])
         #lc_file = os.path.join('./obs_paper/absolute_mag_lc/outdir_BNS', "%d.dat" %  indices[index])
         
                 # fixed scheduling time as observation plan

--- a/nmma/em/detect_lightcurves.py
+++ b/nmma/em/detect_lightcurves.py
@@ -172,7 +172,6 @@ def main():
         
         lcs[index] = np.loadtxt(lc_file)
         
-        print(lcs)
   
 
         efffile = os.path.join(outdir, f"efficiency_true_{indices[index]}.txt")


### PR DESCRIPTION
`.  These files are for some, an update and a modification to allow the reading, the simulations of the  light curves  as well as their detections with the ZTF and Rubin Observatory.  In the 'doc' folder tutorial ``gwemopt_light_curves_detection.md`` accompanies this pull request to allow 'splitting' the CBCs of the Farah distribution into BNS, NSBH. As well as the simulation of their detection with ``gwemopt``. 

This tutorial is a start, in the short term we will add the **Hubble constant** simulation procedure used in the paper ``**Updated observing scenarios and projections for H0 during the IGWN's O4 and O5**'' and in the long term the **EOS** from the GW posterior simulation in **Bilby** to the EM posterior in **NMMA**, then to their combination. 