### PR TITLE
Add more arm64 Mac installation troubleshooting

### DIFF
--- a/doc/installation.md
+++ b/doc/installation.md
@@ -8,13 +8,10 @@ Ubuntu 20.04 is available for free download on Microsoft Store.
 **Installing Anaconda3**
 
 On your Linux/WSL terminal, run the following commands to install anaconda (replace 5.3.1 by the latest version):
-
-
-* $ wget https://repo.anaconda.com/archive/Anaconda3-5.3.1-Linux-x86_64.sh
-
-
-* $ bash Anaconda3-5.3.1-Linux-x86_64.sh
-
+```
+$ wget https://repo.anaconda.com/archive/Anaconda3-5.3.1-Linux-x86_64.sh
+$ bash Anaconda3-5.3.1-Linux-x86_64.sh
+```
 
 (For 32-bit installation, skip the ‘_64’ in both commands)
 
@@ -22,10 +19,9 @@ NOTE: If you already have Anaconda3 installed, please make sure that it is updat
 versions of python installed in usr/lib/ directory as it can cause version conflicts while installing dependencies.
 
 Now do:
-
-
-* $ conda update --all
-
+```
+$ conda update --all
+```
 
 **Cloning the NMMA repository**
 
@@ -36,80 +32,68 @@ Fork the NMMA repository given below:
 
 
 Note that we link above to the main branch, but suggest making changes on your own fork (please also see our [contributing guide](./contributing.html)). Now, after forking, run the following command to clone the repository into your currently directory (by default, in your home directory):
+```
+$ git clone https://github.com/your_github_username/nmma
+```
 
-
-* $ git clone https://github.com/your_github_username/nmma
 Change directory to the nmma folder:
-
-
+```
 * $ cd nmma
-
+```
 
 ## Main Installation
 
 Create a new environment using this command (environment name is nmma_env in this case):
-
-
-* $ conda create --name nmma_env python=3.8
-
-
-* $ conda activate nmma_env
-
+```
+$ conda create --name nmma_env python=3.8
+$ conda activate nmma_env
+```
 
 NOTE: If this gives an error like: CommandNotFoundError: Your shell has not been properly configured to use 'conda activate', then run:
-
-
-* $ source ~/anaconda3/etc/profile.d/conda.sh
-
+```
+$ source ~/anaconda3/etc/profile.d/conda.sh
+```
 
 then proceed with conda activate nmma_env.
 
 
 Get the latest pip version
-
-
-* $ pip install --upgrade pip
-
+```
+$ pip install --upgrade pip
+```
 
 Check python and pip version like this:
-
-
-* $ python --version
-* $ pip --version
-
+```
+$ python --version
+$ pip --version
+```
 
 Python 3.8 and above and Pip 21.2 and above is ideal for this installation. It is recommended to update these for your installation.
 
-For the moment we advise Linux users to avoid using python3.9 and python3.10 in their nmma environment this can generate major problems for the operation. So use preferably python3.8.
+For the moment we advise Linux users to avoid using Python 3.9 and Python 3.10 in their nmma environment; this can generate major problems for the operation. Preferably, use Python 3.8.
 
 Install mpi4py:
-
-
-* $ conda install mpi4py
-
+```
+$ conda install mpi4py
+```
 OR
-
-
-* $ pip install mpi4py
-
+```
+$ pip install mpi4py
+```
 
 Install parallel-bilby:
-
-
-* $ conda install -c conda-forge parallel-bilby
-
-
+```
+$ conda install -c conda-forge parallel-bilby
+```
 OR
+```
+$ pip install parallel-bilby
+```
 
-
-* $ pip install parallel-bilby
-
-
-
-Install pymultinest
-
-* $ conda install -c conda-forge pymultinest
-
+Install pymultinest (note this line may not work for arm64 Macs; see specifc instructions below)
+```
+$ conda install -c conda-forge pymultinest
+```
 
 NOTE: In case an error comes up during an NMMA analysis of the form:
 
@@ -122,16 +106,14 @@ Then, for using the PyMultinest library, it is required to get and compile the M
 https://johannesbuchner.github.io/PyMultiNest/install.html
 
 
-
-
-
-Use the command below to install the dependencies given in requirements.txt file which are necessary for NMMA:
+Use the commands below to install the dependencies given in requirements.txt file which are necessary for NMMA:
 
 ```
-python setup.py install
+$ pip install -r requirements.txt
+$ python setup.py install
 ```
 
-If any package appeared to have an issue installing, you can check by attempting to install it again using pip:
+NOTE: there is an issue pip installing `pyfftw` on arm64 Mac systems; see the dedicated section below for a solution. If any package appeared to have an issue installing, you can first check by attempting to install it again using pip:
 
 * $ pip install importlib_resources
 
@@ -159,10 +141,10 @@ if not covered by python setup.py install. Also, if running python setup.py inst
 and redo python setup.py install.
 
 **Known arm64 Mac issues**
-
-For arm64 Macs (e.g. M1, M2), there is an issue installing `pyfftw` with pip (see https://github.com/pyFFTW/pyFFTW/issues/349#issuecomment-1468638458). To address, first run
-* $ brew install fftw
-
+1. For arm64 Macs (e.g. M1, M2), there is an issue installing `pyfftw` with pip (see https://github.com/pyFFTW/pyFFTW/issues/349#issuecomment-1468638458). To address, use `Homebrew` to run
+```
+$ brew install fftw
+```
 then add the following lines to your `.zprofile` or `.bash_profile`:
 ```
 export PATH="/opt/homebrew/bin:$PATH"
@@ -172,11 +154,29 @@ export CFLAGS="-Wno-implicit-function-declaration -I/opt/homebrew/opt/fftw/inclu
 ```
 
 Close and reopen your terminal and run
-* $ pip install pyfftw
-
-There are also issues with `tensorflow` and arm64 Macs. If using `tensorflow`, install it with the following commands:
 ```
-conda install -c apple tensorflow-deps
+$ pip install pyfftw
+```
+You may then need to rerun `pip install -r requirements.txt` to complete the dependency installations.
+
+
+2. The `osx-arm64` conda-forge channel does not include `pymultinest`. Running `pip install -r requirements.txt` should have installed `pymultinest`, but you will still need to install and compile `Multinest` from the source. Within the `nmma` directory, run:
+```
+git clone https://github.com/JohannesBuchner/MultiNest
+cd MultiNest/build
+cmake ..
+make
+```
+Next, add the following lines to your `.zprofile` or `.bash_profile`:
+```
+export LD_LIBRARY_PATH=$HOME/nmma/MultiNest/lib:$LD_LIBRARY_PATH
+export DYLD_LIBRARY_PATH=$HOME/nmma/MultiNest/lib:$DYLD_LIBRARY_PATH
+```
+(NOTE: Modify these paths as appropriate for the location of your `MultiNest` installation. You can also combine the `DYLD_LIBRARY_PATH` lines for `MultiNest` and `fftw` (above) into a single line)
+
+
+3. There are also issues with `tensorflow` and arm64 Macs. If using `tensorflow`, install it with the following commands:
+```
 pip install tensorflow-macos
 pip install tensorflow-metal
 ```
@@ -186,10 +186,12 @@ pip install tensorflow-metal
 
 Run the following commands:
 
-* $ ipython
-* import nmma
-* import nmma.em.analysis
-* import nmma.eos.create_injection
+```
+$ ipython
+import nmma
+import nmma.em.analysis
+import nmma.eos.create_injection
+```
 
 NOTE (Okay, last one!): if everything is ok, it's the end of the installation. But in case it shows that such-and-such modules are absent, feel free to install those modules by visiting their anaconda documentation and install
 those with their given commands. In case modules like afterglowpy and dust_extinction are needed, don't hesitate to do it with pip (normally it shouldn't happen), but some modules may not install correctly in case of disturbance.
@@ -197,9 +199,9 @@ those with their given commands. In case modules like afterglowpy and dust_extin
 Please pay special attention to the `import nmma.em.analysis` and make sure that it does not generate any errors.
 
 Unfortunately, due to the web of package requirements that NMMA depends on, running setup.py does not typically finish without errors the first time through. Experience has shown that in the vast majority of cases, simply pinning versions such as:
-
-	pip install astropy==4.3.1
-
+```
+pip install astropy==4.3.1
+```
 and then trying again is sufficient for completion of the installation. This instruction file will likely cover the issues you might face during your installation. However, please open issues on GitHub if there appear to be unresolvable conflicts.
 
 


### PR DESCRIPTION
This PR adds more details about installing `nmma` on an arm64 Mac based on continued experiments with the code. It also updates how code is formatted in the docs to be more distinguishable from the rest of the text.