### PR TITLE
Update utils.py: correctly identify photosphere in metzger_lc

### DIFF
--- a/nmma/em/utils.py
+++ b/nmma/em/utils.py
@@ -1105,7 +1105,7 @@ def metzger_lc(t_day, param_dict):
 
         tau[mprec - 1, j] = tau[mprec - 2, j]
         # photosphere
-        pig = np.argmin(np.abs(tau[:, j]) - 1)
+        pig = np.argmin(np.abs(tau[:, j] - 1))
         vphoto[j] = vm[pig]
         Rphoto[j] = vphoto[j] * t[j]
         mphoto[j] = m[pig]


### PR DESCRIPTION
absolute value was only acting on the tau array, not (tau-1), meaning that the photosphere was being identified as being at the largest ejecta radius. fixed to correctly identify photosphere as being located near minimum of (tau-1) array.