### PR TITLE
Zenodo web scraping: smarter headers

### DIFF
--- a/nmma/utils/models.py
+++ b/nmma/utils/models.py
@@ -43,9 +43,21 @@ def clear_data_home(models_home=None):
 
 
 def get_latest_zenodo_doi(permanent_doi):
-    r = requests.get(f"https://zenodo.org/record/{permanent_doi}", allow_redirects=True)
-    data = r.text.split("10.5281/zenodo.")[1]
-    doi = re.findall(r"^\d+", data)[0]
+    headers={ # we emulate a browser request with a recent chrome version to avoid zenodo blocking us
+        'X-Requested-With': 'XMLHttpRequest',
+        'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36',
+        'Accept': '*/*',
+        'Host': 'zenodo.org',
+        'Connection': 'keep-alive',
+        'Pragma': 'no-cache',
+        'Cache-Control': 'no-cache'
+    }
+    r = requests.get(f"https://zenodo.org/record/{permanent_doi}", allow_redirects=True, headers=headers)
+    try:
+        data = r.text.split("10.5281/zenodo.")[1]
+        doi = re.findall(r"^\d+", data)[0]
+    except Exception as e:
+        raise ValueError(f'Could not find latest DOI: {str(e)}')
     return doi
 
 

--- a/nmma/utils/models.py
+++ b/nmma/utils/models.py
@@ -66,7 +66,8 @@ def download(file_info):
     resp = requests.get(url, stream=True)
     total = int(resp.headers.get("content-length", 0))
     chunk_size = 1024
-    with open(filepath, "wb") as f, tqdm(
+    file_content = b""
+    with tqdm(
         total=total,
         unit="iB",
         unit_scale=True,
@@ -74,8 +75,16 @@ def download(file_info):
         desc=f"{str(filepath).split('/')[-1]}",
     ) as pbar:
         for chunk in resp.iter_content(chunk_size=chunk_size):
-            size = f.write(chunk)
-            pbar.update(size)
+            file_content += chunk
+            pbar.update(len(chunk))
+
+    if len(file_content) != total:
+        raise ValueError(
+            f"Downloaded file {filepath} is incomplete. "
+            f"Only {len(file_content)} of {total} bytes were downloaded."
+        )
+    with open(filepath, "wb") as f:
+        f.write(file_content)
 
     return filepath
 


### PR DESCRIPTION
This is an attempt to get around the 'outdated browser' issue some users encountered. Ideally, this needs to be tried by someone with that issue before merging.

PS: Wait before merging even if confirmed that this works. I'm changing the model download method to not partially write to file.