### PR TITLE
Avoid training error for new models by specifying filters

### DIFF
--- a/nmma/em/create_svdmodel.py
+++ b/nmma/em/create_svdmodel.py
@@ -227,6 +227,7 @@ def main():
         mag_ncoeff=args.svd_ncoeff,
         interpolation_type=args.interpolation_type,
         model_parameters=training_model.model_parameters,
+        filters=filts,
     )
     if args.plot:
         # we can plot an example where we compare the model performance

--- a/nmma/em/model.py
+++ b/nmma/em/model.py
@@ -181,10 +181,10 @@ class SVDLightCurveModel(object):
             self.svd_path = svd_path
 
         if self.interpolation_type == "sklearn_gp":
-            _, model_filters = get_model(
-                self.svd_path, f"{self.model}", filters=filters
-            )
             if filters is None:
+                _, model_filters = get_model(
+                    self.svd_path, f"{self.model}", filters=filters
+                )
                 self.filters = model_filters
 
             modelfile = os.path.join(self.svd_path, "{0}.pkl".format(model))
@@ -241,10 +241,10 @@ class SVDLightCurveModel(object):
             tf.get_logger().setLevel("ERROR")
             from tensorflow.keras.models import load_model
 
-            _, model_filters = get_model(
-                self.svd_path, f"{self.model}_tf", filters=filters
-            )
             if filters is None:
+                _, model_filters = get_model(
+                    self.svd_path, f"{self.model}_tf", filters=filters
+                )
                 self.filters = model_filters
 
             modelfile = os.path.join(self.svd_path, "{0}_tf.pkl".format(model))


### PR DESCRIPTION
This PR allows filter specification in `create_svdmodel` to avoid a downstream call to `get_model` that raises an error if the model is not on Zenodo (which will often be the case if training a new model). Resolves #123.