### PR TITLE
Name generated lightcurves after label keyword

### DIFF
--- a/nmma/em/create_lightcurves.py
+++ b/nmma/em/create_lightcurves.py
@@ -202,7 +202,9 @@ def main(args=None):
     except AttributeError:
         pass
     if refresh:
-        refresh_models_list(models_home=args.svd_path if args.svd_path not in [None, ''] else None)
+        refresh_models_list(
+            models_home=args.svd_path if args.svd_path not in [None, ""] else None
+        )
 
     seed = args.generation_seed
     np.random.seed(seed)

--- a/nmma/em/create_lightcurves.py
+++ b/nmma/em/create_lightcurves.py
@@ -252,7 +252,12 @@ def main(args=None):
     mag_ds = {}
     for index, row in injection_df.iterrows():
 
-        injection_outfile = os.path.join(args.outdir, "%d.dat" % simulation_id[index])
+        if len(injection_df) == 1:
+            injection_outfile = os.path.join(args.outdir, "%s.dat" % args.label)
+        else:
+            injection_outfile = os.path.join(
+                args.outdir, f"{args.label}_{simulation_id[index]}.dat"
+            )
         if os.path.isfile(injection_outfile):
             try:
                 mag_ds[index] = read_lightcurve_file(injection_outfile)

--- a/nmma/tests/injections.py
+++ b/nmma/tests/injections.py
@@ -141,7 +141,7 @@ def lightcurveInjectionTest(model_name, model_lightcurve_function):
         create_lightcurves.main(args)
 
         command_line_lightcurve_file = os.path.join(
-            output_directory, f"{injection_df['simulation_id']}.dat"
+            output_directory, f"{command_line_lightcurve_label}.dat"
         )
         assert os.path.exists(
             command_line_lightcurve_file


### PR DESCRIPTION
This PR names generated lightcurves using the `--label` keyword, e.g. "injection_Bu2022Ye.dat". If there is more than one injection, light curves will also be subscripted with the injection's `simulation_id`, e.g. "injection_Bu2022Ye_0.dat". Resolves #137