### PR TITLE
check output directory length

### DIFF
--- a/nmma/em/analysis.py
+++ b/nmma/em/analysis.py
@@ -331,6 +331,9 @@ def main(args=None):
     if args is None:
         parser = get_parser()
         args = parser.parse_args()
+    if len(args.outdir) > 64:
+        print("WARNING: output directory name is too long, it should not be longer than 64 characters")
+        exit()
 
     refresh = False
     try:

--- a/nmma/em/analysis.py
+++ b/nmma/em/analysis.py
@@ -331,9 +331,10 @@ def main(args=None):
     if args is None:
         parser = get_parser()
         args = parser.parse_args()
-    if len(args.outdir) > 64:
-        print("WARNING: output directory name is too long, it should not be longer than 64 characters")
-        exit()
+    if args.sampler == "pymultinest":
+        if len(args.outdir) > 64:
+            print("WARNING: output directory name is too long, it should not be longer than 64 characters")
+            exit()
 
     refresh = False
     try:


### PR DESCRIPTION
To check the length of output directory (should not be longer than 64 characters.)