### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@ __pycache__/
 nmma.egg-info/
 .DS_Store
 
+# development
+.vscode/
+
 # models
-svdmodels/Bu2019lm_lbol.pkl
-svdmodels/Bu2019lm_mag.pkl
+svdmodels/


### PR DESCRIPTION
now ignores all items in the svdmodels and .vscode folders. specific svdmodels files being ignored is less necessary with the zenodo changes that have been implemented recently