### PR TITLE
Add --data-time-unit argument to svdmodel_benchmark

### DIFF
--- a/nmma/em/io.py
+++ b/nmma/em/io.py
@@ -219,6 +219,7 @@ def read_photometry_files(
                         "uvot_v": "uvot::v",
                         "uvot_uvm2": "uvot::uvm2",
                         "uvot_uvw1": "uvot::uvw1",
+                        "uvot_uvw2": "uvot::uvw2",
                         "uvot_white": "uvot::white",
                         "time": "t",
                     },


### PR DESCRIPTION
This PR adds the `--data-time-unit` argument to `svdmodel_benchmark` to support grids with time units other than days. It also adds the `uvot__uvw2` filter to the column list that is used when reading grids in `.h5` format.