### PR TITLE
remove nans from injection test

### DIFF
--- a/nmma/tests/injections.py
+++ b/nmma/tests/injections.py
@@ -237,8 +237,8 @@ def lightcurveInjectionTest(model_name, model_lightcurve_function):
         for filter_name in filters_from_function:
             assert all(
                 np.isclose(
-                    lightcurve_from_function[filter_name],
-                    lightcurve_from_command_line[filter_name],
+                    lightcurve_from_function[filter_name][~np.isnan(lightcurve_from_function[filter_name])],
+                    lightcurve_from_command_line[filter_name][~np.isnan(lightcurve_from_command_line[filter_name])],
                     rtol=1e-3,
                 )
             ), f"lightcurve tolerance for {filter_name} exceeded"


### PR DESCRIPTION
Sometimes, when the lightcurves generated from the injection paramete…rs contain nans. This asserts an error in the comparison np.isclose between the lightcurves from the commandline and the function, although they are the same. This is fixed by excluding the nans in the comparison now.