### PR TITLE
Accelerate GW sampling

### DIFF
--- a/nmma/em/injection_summary.py
+++ b/nmma/em/injection_summary.py
@@ -357,9 +357,7 @@ def main():
     c = 299792458.0 * 1e-3
 
     radius, mass, Lambda = np.loadtxt(args.eos_file, unpack=True, usecols=[0, 1, 2])
-    interp_mass_lambda = interp.interp1d(mass, Lambda)
-    interp_mass_radius = interp.interp1d(mass, radius)
-    R14_true = interp_mass_radius(1.4)
+    R14_true = np.interp(1.4, mass, radius)
 
     n_live_points = 1000
     evidence_tolerance = 0.5
@@ -468,9 +466,10 @@ def main():
                 if not os.path.isdir(EOSDir):
                     os.makedirs(EOSDir)
 
-                mMax, rMax, lam1, lam2, r1, r2 = EOS2Parameters(
-                    interp_mass_radius,
-                    interp_mass_lambda,
+                mMax, rMax, lam1, lam2, r1, r2, R_14, R_16 = EOS2Parameters(
+                    mass,
+                    radius,
+                    Lambda,
                     row["mass_1_source"],
                     row["mass_2_source"],
                 )

--- a/nmma/em/lightcurve_marginalization.py
+++ b/nmma/em/lightcurve_marginalization.py
@@ -251,19 +251,12 @@ def main():
     global EOS_data
     EOS_data, weights = {}, []
     for EOSIdx in range(0, Neos):
-        data = np.loadtxt("{0}/{1}.dat".format(args.eos_dir, EOSIdx + 1))
+        data = np.loadtxt("{0}/{1}.dat".format(args.eos_dir, EOSIdx + 1), usecols = [0,1,2])
         EOS_data[EOSIdx] = {}
         EOS_data[EOSIdx]["R"] = np.array(data[:, 0])
         EOS_data[EOSIdx]["M"] = np.array(data[:, 1])
         EOS_data[EOSIdx]["Lambda"] = np.array(data[:, 2])
         EOS_data[EOSIdx]["weight"] = EOS_GW170817[EOSIdx]
-
-        EOS_data[EOSIdx]["interp_mass_lambda"] = interp.interp1d(
-            EOS_data[EOSIdx]["M"], EOS_data[EOSIdx]["Lambda"]
-        )
-        EOS_data[EOSIdx]["interp_mass_radius"] = interp.interp1d(
-            EOS_data[EOSIdx]["M"], EOS_data[EOSIdx]["R"]
-        )
 
         weights.append(EOS_data[EOSIdx]["weight"])
 
@@ -359,12 +352,14 @@ def main():
         theta_jn = data_out["theta_jn"][idy]
         tilt1, tilt2 = data_out["tilt1"][idy], data_out["tilt2"][idy]
 
-        mMax, rMax, lam1, lam2, r1, r2 = EOS2Parameters(
-            EOS_data[idx]["interp_mass_radius"],
-            EOS_data[idx]["interp_mass_lambda"],
+        mMax, rMax, lam1, lam2, r1, r2, R_14, R_16 = EOS2Parameters(
+            EOS_data[idx]["M"],
+            EOS_data[idx]["R"],
+            EOS_data[idx]["Lambda"],
             m1,
             m2,
         )
+        
         params = {
             "luminosity_distance": dist,
             "chirp_mass": mchirp,

--- a/nmma/eos/create_injection.py
+++ b/nmma/eos/create_injection.py
@@ -292,12 +292,10 @@ def main(args=None):
 
     if not args.original_parameters:
         # load the EOS
-        radii, masses, lambdas = np.loadtxt(
+        radius_val, mass_val, Lambda_val= np.loadtxt(
             args.eos_file, usecols=[0, 1, 2], unpack=True
         )
-        interp_mass_radius = scipy.interpolate.interp1d(masses, radii)
-        interp_mass_lambda = scipy.interpolate.interp1d(masses, lambdas)
-
+        
     # load the injection json file
     if args.injection_file:
         if args.injection_file.endswith(".json"):
@@ -386,9 +384,10 @@ def main(args=None):
     radius_2 = []
 
     for injIdx in range(0, Ninj):
-        mMax, rMax, lam1, lam2, r1, r2 = EOS2Parameters(
-            interp_mass_radius,
-            interp_mass_lambda,
+        mMax, rMax, lam1, lam2, r1, r2, R_14, R_16 = EOS2Parameters(
+            mass_val, 
+            radius_val, 
+            Lambda_val,
             dataframe["mass_1_source"][injIdx],
             dataframe["mass_2_source"][injIdx],
         )
@@ -406,8 +405,8 @@ def main(args=None):
     dataframe["lambda_2"] = np.array(lambda_2)
     dataframe["radius_1"] = np.array(radius_1)
     dataframe["radius_2"] = np.array(radius_2)
-    dataframe["R_16"] = np.ones(len(dataframe)) * interp_mass_radius(1.6)
-    dataframe["R_14"] = np.ones(len(dataframe)) * interp_mass_radius(1.4)
+    dataframe["R_16"] = np.ones(len(dataframe)) * R_16
+    dataframe["R_14"] = np.ones(len(dataframe)) * R_14
 
     if args.eject:
         if args.binary_type == "BNS":

--- a/nmma/pbilby/analysis/main.py
+++ b/nmma/pbilby/analysis/main.py
@@ -147,6 +147,7 @@ def analysis_runner(
                 # Reinstate the pool and map (not saved in the pickle)
                 logger.info(f"Read in resume file with sampling_time = {sampling_time}")
                 sampler.pool = pool
+                sampler.queue_size = pool.size
                 sampler.M = pool.map
                 sampler.loglikelihood.pool = pool
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 future
 bilby>=2.1.1
 bilby_pipe>=1.1.0
+parallel_bilby>=2.0.2
 colorcet
 numpy>=1.9
 matplotlib>=2.0
@@ -9,6 +10,7 @@ pandas>=1.3.4
 astropy>=4.3.1
 scikit-learn>=1.0.2
 pymultinest
+nestcheck
 sncosmo
 dust_extinction
 arviz


### PR DESCRIPTION
EOS are now only loaded when needed and not stored in the MultimessengerConversion object anymore. This changes the EOS2Parameters function, which is backtracked. Additionally the queue size is now always set to the size of the pool and requirements.txt are updated.