### PR TITLE
Remove log10(param) lines in model_parameters.py to reflect new AnBa2022 params

### DIFF
--- a/nmma/em/model_parameters.py
+++ b/nmma/em/model_parameters.py
@@ -20,11 +20,6 @@ def AnBa2022(data):
             )
         ]
 
-        # Best to interpolate mass in log10 space
-        rr[0] = np.log10(rr[0])
-        rr[2] = np.log10(rr[2])
-        rr[3] = np.log10(rr[3])
-
         data_out[key] = {
             param: rr[idx] for param, idx in zip(parameters, parameters_idx)
         }


### PR DESCRIPTION
This PR removes three lines that take the `log10` of parameters input to the `AnBa2022` model. The parameters in question are now input to AnBa2022 in log format, so there is no need to take another log.

See #177 for a discussion of additional steps needed to update the `AnBa2022` model across the repo.