### PR TITLE
Rename Bu2022Ye KNtimeshift prior

### DIFF
--- a/priors/Bu2022Ye.prior
+++ b/priors/Bu2022Ye.prior
@@ -5,4 +5,4 @@ log10_mej_wind = Uniform(name='log10_mej_wind', minimum=-3., maximum=-0.5, latex
 vej_wind = Uniform(name='vej_wind', minimum=0., maximum=0.3, latex_label='$V^{\\rm{wind}}_{\\rm{ej}}$')
 inclination_EM = Sine(name='inclination_EM', minimum=0., maximum=np.pi/2., latex_label='$\\iota$')
 luminosity_distance = Uniform(minimum=0.0, maximum=200., name='luminosity_distance',latex_label='$D_L$')
-KNtimeshift = Uniform(minimum=-2.0, maximum=1.0, name='trigger_time',latex_label='$t_0$')
+KNtimeshift = Uniform(minimum=-2.0, maximum=1.0, name='KNtimeshift',latex_label='$t_0$')


### PR DESCRIPTION
This PR updates the name of the KNtimeshift prior for Bu2022Ye (from `trigger_time` to `KNtimeshift`).