### PR TITLE
adds dependabot

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,7 +1,6 @@
 version: 2
-
 updates:
   - package-ecosystem: "pip"
-  directory: "/"
-  schedule:
-    interval: "weekly"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,7 @@
+version: 2
+
+updates:
+  - package-ecosystem: "pip"
+  directory: "/"
+  schedule:
+    interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Looking at the all `*_requirements.txt` shows that only `Sphinx` is pinned to 4.4.0. And rest all required packages are above a certain version, hence the latest versions are installed. Not sure, how `dependabot` will be useful. 