### PR TITLE
adds warning that KNtimeshift is deprecated

### DIFF
--- a/nmma/em/likelihood.py
+++ b/nmma/em/likelihood.py
@@ -128,7 +128,12 @@ class OpticalLightCurve(Likelihood):
             usedIdx = np.where(np.isfinite(mag_app_filt))[0]
             sample_times_used = self.sample_times[usedIdx]
             mag_app_used = mag_app_filt[usedIdx]
-            t0 = self.parameters["timeshift"]
+            try:
+                t0 = self.parameters["timeshift"]
+            except KeyError:
+                print("Warning: the 'KNtimeshift' parameter is deprecated as of nmma 0.0.19, please update your prior to use 'timeshift' instead")
+                t0 = self.parameters["KNtimeshift"]
+                continue
             if len(mag_app_used) > 0:
                 mag_app_interp[filt] = interp1d(
                     sample_times_used + t0,

--- a/nmma/em/likelihood.py
+++ b/nmma/em/likelihood.py
@@ -133,7 +133,6 @@ class OpticalLightCurve(Likelihood):
             except KeyError:
                 print("Warning: the 'KNtimeshift' parameter is deprecated as of nmma 0.0.19, please update your prior to use 'timeshift' instead")
                 t0 = self.parameters["KNtimeshift"]
-                continue
             if len(mag_app_used) > 0:
                 mag_app_interp[filt] = interp1d(
                     sample_times_used + t0,


### PR DESCRIPTION
Recent update breaks compatibility with old prior files due to renaming of KNtimeshift parameter to timeshift, this PR has a few lines of code that restore compatibility but warns users that KNtimeshift will no longer work at some point in the future.