### PR TITLE
Restrict scikit-learn version to <1.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ matplotlib>=2.0
 scipy>=1.7.1
 pandas>=1.3.4
 astropy>=4.3.1
-scikit-learn>=1.0.2
+scikit-learn>=1.0.2,<1.2
 pymultinest
 sncosmo
 dust_extinction


### PR DESCRIPTION
This PR restricts the scikit-learn version in `requirements.txt` to <1.2 (in addition to >=1.0.2). Assuming the tests pass with the different package version, this resolves #173. The `.joblib` files loaded when setting `--ztf-uncertainties` and `--ztf-sampling` were likely generated using an older version of scikit-learn, raising unusual errors when attempting to load them with newer versions of the package. A longer-term solution will be to regenerate those files with newer code so we don't need to constrain the package version.