### PR TITLE
Fixed missing Sr2023 model

### DIFF
--- a/nmma/em/model.py
+++ b/nmma/em/model.py
@@ -620,6 +620,7 @@ class HostGalaxyLightCurveModel(object):
     def __init__(
         self,
         sample_times,
+        model="Sr2023",
         parameter_conversion=None,
         filters=None,
     ):
@@ -644,6 +645,7 @@ class HostGalaxyLightCurveModel(object):
 
         self.sample_times = sample_times
         self.parameter_conversion = parameter_conversion
+        self.model = model
         self.filters = filters
 
     def __repr__(self):


### PR DESCRIPTION
This pull request corrects the missing issue of self.model in 'HostGalaxyLightCurveModel(model={self.model}'. 
Here we add model = 'Sr2023'.

