### PR TITLE
Set random seed for python/numpy/tf during nn training

### DIFF
--- a/nmma/em/create_svdmodel.py
+++ b/nmma/em/create_svdmodel.py
@@ -165,6 +165,12 @@ def main():
         default=False,
         help="Refresh the list of models available on Zenodo",
     )
+    parser.add_argument(
+        "--random-seed",
+        type=int,
+        default=42,
+        help="random seed to set during training",
+    )
     args = parser.parse_args()
 
     refresh = False
@@ -246,6 +252,7 @@ def main():
         ncpus=args.ncpus,
         univariate_spline=args.use_UnivariateSpline,
         univariate_spline_s=args.UnivariateSpline_s,
+        random_seed=args.random_seed,
     )
 
     light_curve_model = SVDLightCurveModel(

--- a/nmma/em/training.py
+++ b/nmma/em/training.py
@@ -60,6 +60,7 @@ class SVDTrainingModel(object):
         ncpus=1,
         univariate_spline=False,
         univariate_spline_s=2,
+        random_seed=42,
     ):
 
         if interpolation_type not in ["sklearn_gp", "tensorflow", "api_gp"]:
@@ -82,6 +83,7 @@ class SVDTrainingModel(object):
         self.ncpus = ncpus
         self.univariate_spline = univariate_spline
         self.univariate_spline_s = univariate_spline_s
+        self.random_seed = random_seed
         if self.univariate_spline:
             print("The grid will be interpolated to sample_time with UnivariateSpline")
         else:
@@ -397,10 +399,10 @@ class SVDTrainingModel(object):
                 cAmat.T,
                 shuffle=True,
                 test_size=0.1,
-                random_state=8581,
+                random_state=self.random_seed,
             )
 
-            tf.keras.utils.set_random_seed(42)
+            tf.keras.utils.set_random_seed(self.random_seed)
             model = Sequential()
             # One/few layers of wide NN approximate GP
             model.add(

--- a/nmma/em/training.py
+++ b/nmma/em/training.py
@@ -400,7 +400,7 @@ class SVDTrainingModel(object):
                 random_state=8581,
             )
 
-            np.random.RandomState(42)
+            tf.keras.utils.set_random_seed(42)
             model = Sequential()
             # One/few layers of wide NN approximate GP
             model.add(


### PR DESCRIPTION
This PR sets the random seed for python/numpy/tensorflow during NN training. Previously only the numpy random state was set, leading to a variation in training results from run to run.