### PR TITLE
Limit pandas to <2.0 for .pkl file compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ colorcet
 numpy>=1.9
 matplotlib>=2.0
 scipy>=1.7.1
-pandas>=1.3.4
+pandas>=1.3.4,<2.0
 astropy>=4.3.1
 scikit-learn>=1.0.2,<1.2
 pymultinest


### PR DESCRIPTION
This PR limits the required pandas version to < 2.0 to avoid a `TypeError` with pickled ZTF files (see #231).