### PR TITLE
Fix refresh models list typo

### DIFF
--- a/nmma/em/analysis.py
+++ b/nmma/em/analysis.py
@@ -367,7 +367,7 @@ def main(args=None):
 
     refresh = False
     try:
-        refresh = args.refresh_model_list
+        refresh = args.refresh_models_list
     except AttributeError:
         pass
     if refresh:


### PR DESCRIPTION
nmma/em/analysis.py#L370 was missing an 's' when trying to get the argument