### PR TITLE
Use the same model.pkl file for all interpolation types

### DIFF
--- a/nmma/em/model.py
+++ b/nmma/em/model.py
@@ -210,7 +210,12 @@ class SVDLightCurveModel(object):
 
         self.svd_path = get_models_home(svd_path)
 
-        core_model_name = model.split("_")[0]
+        # Some models have underscores. Keep those, but drop '_tf' if it exists
+        model_name_components = model.split("_")
+        if "tf" in model_name_components:
+            model_name_components.remove("tf")
+        core_model_name = "_".join(model_name_components)
+
         modelfile = os.path.join(self.svd_path, f"{core_model_name}.pkl")
 
         if self.interpolation_type == "sklearn_gp":

--- a/nmma/em/model.py
+++ b/nmma/em/model.py
@@ -210,6 +210,9 @@ class SVDLightCurveModel(object):
 
         self.svd_path = get_models_home(svd_path)
 
+        core_model_name = model.split("_")[0]
+        modelfile = os.path.join(self.svd_path, f"{core_model_name}.pkl")
+
         if self.interpolation_type == "sklearn_gp":
             if not local_only:
                 _, model_filters = get_model(
@@ -218,7 +221,6 @@ class SVDLightCurveModel(object):
                 if filters is None and model_filters is not None:
                     self.filters = model_filters
 
-            modelfile = os.path.join(self.svd_path, "{0}.pkl".format(model))
             if os.path.isfile(modelfile):
                 with open(modelfile, "rb") as handle:
                     self.svd_mag_model = pickle.load(handle)
@@ -226,7 +228,7 @@ class SVDLightCurveModel(object):
                 if self.filters is None:
                     self.filters = list(self.svd_mag_model.keys())
 
-                outdir = modelfile.replace(".pkl", "")
+                outdir = os.path.join(self.svd_path, f"{model}")
                 for filt in self.filters:
                     outfile = os.path.join(outdir, f"{filt}.pkl")
                     if not os.path.isfile(outfile):
@@ -262,7 +264,6 @@ class SVDLightCurveModel(object):
         elif self.interpolation_type == "api_gp":
             from .training import load_api_gp_model
 
-            modelfile = os.path.join(self.svd_path, "{0}_api.pkl".format(model))
             if os.path.isfile(modelfile):
                 with open(modelfile, "rb") as handle:
                     self.svd_mag_model = pickle.load(handle)
@@ -285,7 +286,6 @@ class SVDLightCurveModel(object):
                 if filters is None:
                     self.filters = model_filters
 
-            modelfile = os.path.join(self.svd_path, "{0}_tf.pkl".format(model))
             if os.path.isfile(modelfile):
                 with open(modelfile, "rb") as handle:
                     self.svd_mag_model = pickle.load(handle)
@@ -293,7 +293,7 @@ class SVDLightCurveModel(object):
                 if self.filters is None:
                     self.filters = list(self.svd_mag_model.keys())
 
-                outdir = modelfile.replace(".pkl", "")
+                outdir = os.path.join(self.svd_path, f"{model}_tf")
                 for filt in self.filters:
                     outfile = os.path.join(outdir, f"{filt}.h5")
                     if not os.path.isfile(outfile):

--- a/nmma/em/training.py
+++ b/nmma/em/training.py
@@ -453,26 +453,25 @@ class SVDTrainingModel(object):
 
         model_exists = True
 
+        modelfile = os.path.join(self.svd_path, f"{self.model}.pkl")
+
         if self.interpolation_type == "sklearn_gp":
-            modelfile = os.path.join(self.svd_path, f"{self.model}.pkl")
             if not os.path.isfile(modelfile):
                 model_exists = False
-            outdir = modelfile.replace(".pkl", "")
+            outdir = os.path.join(self.svd_path, f"{self.model}")
             for filt in self.filters:
                 outfile = os.path.join(outdir, f"{filt}.pkl")
                 if not os.path.isfile(outfile):
                     model_exists = False
         elif self.interpolation_type == "tensorflow":
-            modelfile = os.path.join(self.svd_path, f"{self.model}_tf.pkl")
             if not os.path.isfile(modelfile):
                 model_exists = False
-            outdir = modelfile.replace(".pkl", "")
+            outdir = os.path.join(self.svd_path, f"{self.model}_tf")
             for filt in self.filters:
                 outfile = os.path.join(outdir, f"{filt}.h5")
                 if not os.path.isfile(outfile):
                     model_exists = False
         elif self.interpolation_type == "api_gp":
-            modelfile = os.path.join(self.svd_path, f"{self.model}_api.pkl")
             if not os.path.isfile(modelfile):
                 model_exists = False
 
@@ -480,9 +479,10 @@ class SVDTrainingModel(object):
 
     def save_model(self):
 
+        modelfile = os.path.join(self.svd_path, f"{self.model}.pkl")
+
         if self.interpolation_type == "sklearn_gp":
-            modelfile = os.path.join(self.svd_path, f"{self.model}.pkl")
-            outdir = modelfile.replace(".pkl", "")
+            outdir = os.path.join(self.svd_path, f"{self.model}")
             if not os.path.isdir(outdir):
                 os.makedirs(outdir)
             for filt in self.svd_model.keys():
@@ -495,8 +495,7 @@ class SVDTrainingModel(object):
                     )
                     del self.svd_model[filt]["gps"]
         elif self.interpolation_type == "tensorflow":
-            modelfile = os.path.join(self.svd_path, f"{self.model}_tf.pkl")
-            outdir = modelfile.replace(".pkl", "")
+            outdir = os.path.join(self.svd_path, f"{self.model}_tf")
             if not os.path.isdir(outdir):
                 os.makedirs(outdir)
             for filt in self.svd_model.keys():
@@ -505,20 +504,20 @@ class SVDTrainingModel(object):
                 del self.svd_model[filt]["model"]
         elif self.interpolation_type == "api_gp":
             get_model(self.svd_path, f"{self.model}_api", self.svd_model.keys())
-            modelfile = os.path.join(self.svd_path, f"{self.model}_api.pkl")
 
         with open(modelfile, "wb") as handle:
             pickle.dump(self.svd_model, handle, protocol=pickle.HIGHEST_PROTOCOL)
 
     def load_model(self):
 
+        modelfile = os.path.join(self.svd_path, f"{self.model}.pkl")
+
         if self.interpolation_type == "sklearn_gp":
             get_model(self.svd_path, f"{self.model}", self.filters)
-            modelfile = os.path.join(self.svd_path, f"{self.model}.pkl")
             with open(modelfile, "rb") as handle:
                 self.svd_model = pickle.load(handle)
 
-            outdir = modelfile.replace(".pkl", "")
+            outdir = os.path.join(self.svd_path, f"{self.model}")
             for filt in self.svd_model.keys():
                 outfile = os.path.join(outdir, f"{filt}.pkl")
                 if not os.path.isfile(outfile):
@@ -533,17 +532,15 @@ class SVDTrainingModel(object):
                 print("Install tensorflow if you want to use it...")
                 return
             get_model(self.svd_path, f"{self.model}_tf", self.filters)
-            modelfile = os.path.join(self.svd_path, f"{self.model}_tf.pkl")
             with open(modelfile, "rb") as handle:
                 self.svd_model = pickle.load(handle)
 
-            outdir = modelfile.replace(".pkl", "")
+            outdir = os.path.join(self.svd_path, f"{self.model}_tf")
             for filt in self.svd_model.keys():
                 outfile = os.path.join(outdir, f"{filt}.h5")
                 self.svd_model[filt]["model"] = load_tf_model(outfile)
         elif self.interpolation_type == "api_gp":
             get_model(self.svd_path, f"{self.model}_api", self.filters)
-            modelfile = os.path.join(self.svd_path, f"{self.model}_api.pkl")
             with open(modelfile, "rb") as handle:
                 self.svd_model = pickle.load(handle)
             for filt in self.svd_model.keys():

--- a/nmma/utils/models.py
+++ b/nmma/utils/models.py
@@ -270,7 +270,7 @@ def get_model(
     filter_format = "pkl"
     if "_tf" in model_name:
         filter_format = "h5"
-    core_model_name = model_name.split("_")[0]
+    core_model_name = model_name.split("_")[:-1]
 
     filepaths = (
         [Path(models_home, f"{core_model_name}.{core_format}")]

--- a/nmma/utils/models.py
+++ b/nmma/utils/models.py
@@ -270,12 +270,15 @@ def get_model(
     filter_format = "pkl"
     if "_tf" in model_name:
         filter_format = "h5"
+    core_model_name = model_name.split("_")[0]
 
     filepaths = (
-        [Path(models_home, f"{model_name}.{core_format}")] if not filters_only else []
+        [Path(models_home, f"{core_model_name}.{core_format}")]
+        if not filters_only
+        else []
     ) + [Path(models_home, model_name, f"{f}.{filter_format}") for f in filters]
     urls = (
-        [f"{base_url}/{model_name}.{core_format}?download=1"]
+        [f"{base_url}/{core_model_name}.{core_format}?download=1"]
         if not filters_only
         else []
     ) + [f"{base_url}/{model_name}_{f}.{filter_format}?download=1" for f in filters]

--- a/nmma/utils/models.py
+++ b/nmma/utils/models.py
@@ -161,7 +161,7 @@ def load_models_list(doi=None, models_home=None):
     if not downloaded_if_missing:
         print("Attempting to retrieve local files...")
 
-    files = [f for f in Path(models_home).glob("*") if f.is_file()]
+    files = [f for f in Path(models_home).glob("*") if f.is_dir()]
     files = [f.stem for f in files]
 
     for f in files:
@@ -270,7 +270,12 @@ def get_model(
     filter_format = "pkl"
     if "_tf" in model_name:
         filter_format = "h5"
-    core_model_name = model_name.split("_")[:-1]
+
+    # Some models have underscores. Keep those, but drop '_tf' if it exists
+    model_name_components = model_name.split("_")
+    if "tf" in model_name_components:
+        model_name_components.remove("tf")
+    core_model_name = "_".join(model_name_components)
 
     filepaths = (
         [Path(models_home, f"{core_model_name}.{core_format}")]


### PR DESCRIPTION
This PR resolves #237 by saving/loading/downloading the same file (formatted as `model.pkl`) for all interpolation types.