### PR TITLE
remove KNTimeshift deprecation warning

### DIFF
--- a/nmma/em/likelihood.py
+++ b/nmma/em/likelihood.py
@@ -128,11 +128,7 @@ class OpticalLightCurve(Likelihood):
             usedIdx = np.where(np.isfinite(mag_app_filt))[0]
             sample_times_used = self.sample_times[usedIdx]
             mag_app_used = mag_app_filt[usedIdx]
-            try:
-                t0 = self.parameters["timeshift"]
-            except KeyError:
-                print("Warning: the 'KNtimeshift' parameter is deprecated as of nmma 0.0.19, please update your prior to use 'timeshift' instead")
-                t0 = self.parameters["KNtimeshift"]
+            t0 = self.parameters["timeshift"]
             if len(mag_app_used) > 0:
                 mag_app_interp[filt] = interp1d(
                     sample_times_used + t0,


### PR DESCRIPTION
using KNTimeshift will now raise a keyerror. Reverts changes made in 4e30aad18e3c8a88ed4bacb22cff75d75cc230c6