### PR TITLE
Add simpler install option for pyfftw on arm64 Mac

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -37,7 +37,7 @@ refer to the developer section below.
 
 .. note::
 
-   The above may not work for arm64 Macs; see specifc instructions `below <#arm64mac>`_. 
+   The above may not work for arm64 Macs; see specifc instructions `below <#arm64mac>`_.
 
 For developers and contributors
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -239,7 +239,13 @@ Install C compiler and cmake:
 #. For arm64 Macs (e.g. M1, M2), there is an issue installing ``pyfftw``
    with pip (see
    https://github.com/pyFFTW/pyFFTW/issues/349#issuecomment-1468638458).
-   To address, use ``Homebrew`` to run
+   To address, first try running
+
+   .. code::
+
+      conda install -c conda-forge pyfftw
+
+   If this completes successfully, re-run any failed installations and continue. Otherwise, use ``Homebrew`` to run
 
    .. code::
 
@@ -266,9 +272,9 @@ Install C compiler and cmake:
    .. tip::
 
       FFTW installation can also be attempted using conda as follows
-   
+
       .. code::
-   
+
          conda install -c conda-forge fftw
          DYLD_LIBRARY_PATH=$HOME/anaconda3/envs/nmma_env
          pip install pyfftw


### PR DESCRIPTION
When setting up new NMMA environments on arm64 Mac architecture, I have found that the command `conda install -c conda-forge pyfftw` successfully runs after the installation fails with pip. This PR updates the installation documentation to list this simple solution as the first to try for arm64 Mac users. 