### PR TITLE
Add flag to skip sampling in analysis.py

### DIFF
--- a/nmma/tests/analysis.py
+++ b/nmma/tests/analysis.py
@@ -12,7 +12,7 @@ def args():
     workingDir = os.path.dirname(__file__)
     dataDir = os.path.join(workingDir, "data")
     svdmodels = os.path.join(workingDir, "../../svdmodels/")
-    
+
     args = Namespace(
         model="Bu2019lm",
         interpolation_type="sklearn_gp",
@@ -72,13 +72,14 @@ def args():
         sampler_kwargs="{}",
         verbose=False,
         local_only=True,
+        skip_sampling=False,
     )
 
     return args
 
 
 def test_analysis(args):
-    
+
     analysis.main(args)
 
 


### PR DESCRIPTION

This PR adds a `--skip-sampling` flag that skips bilby sampling in analysis.py. The intended purpose of this flag is to be combined with `--plot` to generate plots based on the latest checkpoint results for interrupted runs.