### PR TITLE
Enable continued training of existing tensorflow model

### DIFF
--- a/doc/training.md
+++ b/doc/training.md
@@ -77,6 +77,7 @@ This model is then ready to use in an analysis.
 
 	lightcurve-analysis --model Bu2022mv --interpolation-type tensorflow --svd-path svdmodels --outdir outdir --label AT2017gfo --trigger-time 57982.5285236896 --data example_files/lightcurves/GW170817.dat --prior priors/Bu2022mv.prior
 
+To continue training an existing model (e.g. on additional data), set the --continue-training flag.
 
 ### Spectral grids
 

--- a/doc/training.md
+++ b/doc/training.md
@@ -77,7 +77,7 @@ This model is then ready to use in an analysis.
 
 	lightcurve-analysis --model Bu2022mv --interpolation-type tensorflow --svd-path svdmodels --outdir outdir --label AT2017gfo --trigger-time 57982.5285236896 --data example_files/lightcurves/GW170817.dat --prior priors/Bu2022mv.prior
 
-To continue training an existing model (e.g. on additional data), set the --continue-training flag.
+To continue training an existing tensorflow model (e.g. on additional data), set the --continue-training flag.
 
 ### Spectral grids
 

--- a/nmma/em/create_svdmodel.py
+++ b/nmma/em/create_svdmodel.py
@@ -171,6 +171,12 @@ def main():
         default=42,
         help="random seed to set during training",
     )
+    parser.add_argument(
+        "--continue-training",
+        action="store_true",
+        default=False,
+        help="Continue training an existing model",
+    )
     args = parser.parse_args()
 
     refresh = False
@@ -253,6 +259,7 @@ def main():
         univariate_spline=args.use_UnivariateSpline,
         univariate_spline_s=args.UnivariateSpline_s,
         random_seed=args.random_seed,
+        continue_training=args.continue_training,
     )
 
     light_curve_model = SVDLightCurveModel(

--- a/nmma/em/training.py
+++ b/nmma/em/training.py
@@ -1,6 +1,7 @@
 import json
 import os
 import pickle
+import warnings
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -63,7 +64,8 @@ class SVDTrainingModel(object):
         univariate_spline=False,
         univariate_spline_s=2,
         random_seed=42,
-        start_training=True
+        start_training=True,
+        continue_training=False,
     ):
 
         if interpolation_type not in ["sklearn_gp", "tensorflow", "api_gp"]:
@@ -103,15 +105,27 @@ class SVDTrainingModel(object):
 
         self.interpolate_data(data_time_unit=data_time_unit)
 
-        # Only want to train if we must, so check if the model exists
-        model_exists = self.check_model()
-        if not model_exists and start_training:
-            print("Training new model")
+        self.model_exists = self.check_model()
+        self.start_training = start_training
+        self.continue_training = continue_training
+
+        if self.model_exists:
+            print("Model exists... will load that model.")
+            self.load_model()
+        else:
             self.svd_model = self.generate_svd_model()
+            if self.continue_training:
+                warnings.warn(
+                    "Warning: --continue-training set, but no existing model found."
+                )
+
+        if (not self.model_exists and self.start_training) or (
+            self.model_exists and self.continue_training
+        ):
+            print("Training model...")
+            # self.svd_model = self.generate_svd_model()
             self.train_model()
             self.save_model()
-        else:
-            print("Model exists... will load that model.")
 
         self.load_model()
 
@@ -181,7 +195,7 @@ class SVDTrainingModel(object):
         """
         Function that preprocesses the data and performs the SVD decomposition for each filter of the data.
         The SVD is done with np.linalg
-        
+
         Returns:
             svd_model: A dictionary with keys being the filters. The values are dictionaries containing
             the processed values of the parameters, processed values of the data (normalized into a [0, 1] range)
@@ -419,21 +433,25 @@ class SVDTrainingModel(object):
             )
 
             tf.keras.utils.set_random_seed(self.random_seed)
-            model = Sequential()
-            # One/few layers of wide NN approximate GP
-            model.add(
-                Dense(
-                    2048,
-                    activation="relu",
-                    kernel_initializer="he_normal",
-                    input_shape=(train_X.shape[1],),
-                )
-            )
-            model.add(Dropout(dropout_rate))
-            model.add(Dense(self.n_coeff))
 
-            # compile the model
-            model.compile(optimizer="adam", loss="mse")
+            if self.model_exists and self.continue_training:
+                model = self.svd_model[filt]["model"]
+            else:
+                model = Sequential()
+                # One/few layers of wide NN approximate GP
+                model.add(
+                    Dense(
+                        2048,
+                        activation="relu",
+                        kernel_initializer="he_normal",
+                        input_shape=(train_X.shape[1],),
+                    )
+                )
+                model.add(Dropout(dropout_rate))
+                model.add(Dense(self.n_coeff))
+
+                # compile the model
+                model.compile(optimizer="adam", loss="mse")
 
             # fit the model
             training_history = model.fit(

--- a/nmma/em/training.py
+++ b/nmma/em/training.py
@@ -73,6 +73,11 @@ class SVDTrainingModel(object):
                 "interpolation_type must be sklearn_gp, api_gp or tensorflow"
             )
 
+        if (interpolation_type != "tensorflow") and continue_training:
+            raise ValueError(
+                "--continue-training only supported with --interpolation-type tensorflow"
+            )
+
         self.model = model
         self.data = data
         self.model_parameters = parameters


### PR DESCRIPTION
This PR adds a `--continue-training` flag to `create-svdmodel` that allows an existing tensorflow model to be additionally trained. The code raises an error if the user sets `--continue-training` with any other interpolation type.