### PR TITLE
Add tensorflow requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ arviz
 p_tqdm
 ultranest
 tornado
+tensorflow


### PR DESCRIPTION
This PR adds a tensorflow requirement, in light of both the increased use of the module in NMMA and the relative cross-platform ease of installing it compared to several months ago.