### PR TITLE
add apptainer definition file

### DIFF
--- a/nmma.def
+++ b/nmma.def
@@ -1,0 +1,25 @@
+Bootstrap: docker
+From: continuumio/miniconda3:23.9.0-0
+Stage: build
+
+%files
+pyproject.toml /workdir/nmma/
+requirements.txt /workdir/nmma/
+priors/* /workdir/nmma/priors/
+tools/* /workdir/nmma/tools/
+nmma/* /workdir/nmma/nmma/
+
+%post
+/opt/conda/bin/conda config --add channels conda-forge
+/opt/conda/bin/conda install c-compiler libblas libcblas liblapack mpi4py multinest parallel-bilby
+/opt/conda/bin/pip install --upgrade pip
+/opt/conda/bin/pip install -r /workdir/nmma/requirements.txt
+cd /workdir/nmma && /opt/conda/bin/pip install -e .
+
+%runscript
+#!/bin/bash
+exec "$@"
+
+%labels
+Author NMMA Development team
+Version v0.0.1


### PR DESCRIPTION
Add a singularity/apptainer definition file. Image built as `$ apptainer build nmma.sif nmma.def`. I have done basic sanity checks like running help scripts on executables. E.g.
```
$ apptainer run nmma.sif lightcurve-generation -h
Install afterglowpy if you want to simulate afterglows.
Install wrapt_timeout_decorator if you want timeout simulations.
usage: lightcurve-generation [-h] --model MODEL [--svd-path SVD_PATH] --outdir OUTDIR [--outfile-type OUTFILE_TYPE] --label LABEL [--tmin TMIN] [--tmax TMAX] [--dt DT] [--svd-mag-ncoeff SVD_MAG_NCOEFF] [--svd-lbol-ncoeff SVD_LBOL_NCOEFF] [--filters FILTERS]
                             [--generation-seed seed] [--injection PATH] [--joint-light-curve] [--with-grb-injection] [--grb-resolution GRB_RESOLUTION] [--jet-type JET_TYPE] [--plot] [--verbose] [--injection-detection-limit mAB] [--interpolation-type INTERPOLATION_TYPE]
                             [--absolute] [--ztf-sampling] [--ztf-uncertainties] [--ztf-ToO {180,300}] [--rubin-ToO] [--rubin-ToO-type {BNS,NSBH}] [--photometry-augmentation] [--photometry-augmentation-seed seed]
                             [--photometry-augmentation-N-points PHOTOMETRY_AUGMENTATION_N_POINTS] [--photometry-augmentation-filters PHOTOMETRY_AUGMENTATION_FILTERS] [--photometry-augmentation-times PHOTOMETRY_AUGMENTATION_TIMES] [--train-stats]
                             [--refresh-models-list REFRESH_MODELS_LIST] [--xlim [XLIM ...]] [--ylim [YLIM ...]] [--photometric-error-budget PHOTOMETRIC_ERROR_BUDGET] [--increment-seeds]

Inference on kilonova ejecta parameters.

.
.
.
```
Happy to add more tests in case this is helpful.