### PR TITLE
NMMA models - multiple sources

### DIFF
--- a/doc/models.md
+++ b/doc/models.md
@@ -3,7 +3,7 @@
 
 NMMA will be under continuous development meaning that new astrophysical models such as for kilonovae, supernovae, gamma-ray bursts and so on will be implemented over time. Therefore, it is worthwhile to check out the `model_parameters_dict` in models.py from time to time.
 
-We make the interpolated models available here: https://zenodo.org/record/8164628, which are automatically downloaded upon their first request.
+We make the interpolated models available here: https://zenodo.org/record/8039909, https://gitlab.com/Theodlz/nmma-models which are automatically downloaded upon their first request.
 
 ### Kilonovae
 

--- a/nmma/tests/models.py
+++ b/nmma/tests/models.py
@@ -1,0 +1,27 @@
+from ..utils.models import get_model, refresh_models_list
+
+
+def test_download_model():
+    # Test that we can download a model from Zenodo
+    files, filters = get_model(
+        model_name="Ka2017_tf", filters=["ztfg"], source="zenodo"
+    )
+    assert len(files) == 2
+    assert len(filters) == 1
+
+    # Test that we can download a model from GitLab
+    files, filters = get_model(
+        model_name="LANLTP1_tf", filters=["ztfg"], source="gitlab"
+    )
+    assert len(files) == 2
+    assert len(filters) == 1
+
+
+def test_refresh_models_list():
+    # Test that we can refresh the models list from Zenodo
+    models = refresh_models_list(source="zenodo")
+    assert len(models) > 0
+
+    # Test that we can refresh the models list from GitLab
+    models = refresh_models_list(source="gitlab")
+    assert len(models) > 0

--- a/nmma/utils/gitlab.py
+++ b/nmma/utils/gitlab.py
@@ -1,0 +1,201 @@
+from concurrent.futures import ThreadPoolExecutor
+from multiprocessing import cpu_count
+from os.path import exists
+from pathlib import Path
+from os import makedirs
+
+import requests
+from requests.exceptions import ConnectionError
+from yaml import load
+
+from models_tools import *
+
+REPO = "https://gitlab.com/Theodlz/nmma-models"
+
+MODELS = {}
+
+def download_and_decompress(file_info):
+    download(file_info)
+    decompress(file_info[1])
+
+def download_models_list(models_home=None):
+    # first we load the models list from gitlab
+    models_home = get_models_home(models_home)
+    if not exists(models_home):
+        makedirs(models_home)
+    r = requests.get(
+        f"{REPO}/raw/main/models.yaml", allow_redirects=True
+    )
+    with open(Path(models_home, "models.yaml"), "wb") as f:
+        f.write(r.content)
+
+
+def load_models_list(models_home=None):
+
+    models_home = get_models_home(models_home)
+
+    downloaded_if_missing = True
+    if not exists(Path(models_home, "models.yaml")):
+        try:
+            download_models_list(models_home=models_home)
+        except ConnectionError:
+            downloaded_if_missing = False
+            pass
+
+    models = {}
+
+    if downloaded_if_missing:
+        try:
+            from yaml import CLoader as Loader
+        except ImportError:
+            from yaml import Loader
+        try:
+            with open(Path(models_home, "models.yaml"), "r") as f:
+                models = load(f, Loader=Loader)
+        except Exception as e:
+            downloaded_if_missing = False
+            print(
+                f"Could not open the download models list, using local files instead: {str(e)}"
+            )
+
+    if not downloaded_if_missing:
+        print("Attempting to retrieve local files...")
+
+    files = [f for f in Path(models_home).glob("*") if f.is_dir()]
+    files = [f.stem for f in files]
+
+    for f in files:
+        name = f.split("/")[-1]
+        filters = []
+        if exists(Path(models_home, name)):
+            filter_files = [
+                f.stem for f in Path(models_home, name).glob("*") if f.is_file()
+            ]
+            for ff in filter_files:
+                ff = ff.split("/")[-1]
+
+                if name in ff:
+                    ff = ff.replace(name, "")
+
+                if ff.startswith("_"):
+                    ff = ff[1:]
+
+                if ff.endswith("_"):
+                    ff = ff[:-1]
+
+                if ff is not None and ff != "":
+                    filters.append(ff)
+
+        filters = list(set(filters))
+        if name not in models:
+            models[name] = {"filters": filters}
+        elif "filters" not in models[name]:
+            models[name]["filters"] = filters
+        else:
+            models[name]["filters"] = list(set(filters + models[name]["filters"]))
+
+    return models, downloaded_if_missing is False
+
+
+def refresh_models_list(models_home=None):
+    global MODELS
+    models_home = get_models_home(models_home)
+    if exists(Path(models_home, "models.yaml")):
+        Path(models_home, "models.yaml").unlink()
+    models = MODELS
+    try:
+        models = load_models_list(models_home)[0]
+        MODELS = models
+    except Exception as e:
+        raise ValueError(f"Could not load models list: {str(e)}")
+    return models
+
+
+def get_model(
+    models_home=None,
+    model_name=None,
+    filters=[],
+    download_if_missing=True,
+    filters_only=False,
+):
+    global MODELS
+
+    models_home = get_models_home(models_home)
+    used_local = False
+    try:
+        MODELS, used_local = load_models_list(models_home)
+    except Exception as e:
+        raise ValueError(f"Could not load models list: {str(e)}")
+
+    if used_local:
+        print("Could not access GitLab, used local models list instead.")
+
+    base_url = f"{REPO}/raw/main/models"
+    if model_name is None:
+        raise ValueError("model_name must be specified, got None")
+    if model_name not in MODELS:
+        raise ValueError(f"model_name {model_name} not found in models list")
+    model_info = MODELS[model_name]
+
+    if not exists(models_home):
+        makedirs(models_home)
+    if not exists(Path(models_home, model_name)):
+        makedirs(Path(models_home, model_name))
+
+    filter_synonyms = [filt.replace("_", ":") for filt in model_info["filters"]]
+
+    all_filters = list(set(model_info["filters"] + filter_synonyms))
+    if filters in [[], None, ""] and "filters" in model_info:
+        filters = model_info["filters"]
+
+    skipped_filters = [f for f in filters if f in SKIP_FILTERS]
+
+    # remove the skip_filters list from the filters
+    filters = [f for f in filters if f not in SKIP_FILTERS]
+
+    missing_filters = list(set(filters).difference(set(all_filters)))
+    if len(missing_filters) > 0:
+        if used_local:
+            raise ValueError(
+                f"local models list does not have filters {','.join(missing_filters)} for {model_name}"
+            )
+        else:
+            raise ValueError(
+                f'models list from GitLab does not have filters {",".join(missing_filters)} for {model_name}'
+            )
+
+    core_format = "pkl"
+    filter_format = "pkl"
+    if "_tf" in model_name:
+        filter_format = "h5"
+
+    # Some models have underscores. Keep those, but drop '_tf' if it exists
+    model_name_components = model_name.split("_")
+    if "tf" in model_name_components:
+        model_name_components.remove("tf")
+    core_model_name = "_".join(model_name_components)
+
+    filepaths = (
+        [Path(models_home, f"{core_model_name}.{core_format}")]
+        if not filters_only
+        else []
+    ) + [Path(models_home, model_name, f"{f}.{filter_format}") for f in filters]
+    urls = (
+        [f"{base_url}/{core_model_name}.{core_format}"]
+        if not filters_only
+        else []
+    ) + [f"{base_url}/{model_name}/{f}.{filter_format}" for f in filters]
+
+    missing = [(f"{u}.lzma", f"{f}.lzma") for u, f in zip(urls, filepaths) if not f.exists()]
+    if len(missing) > 0:
+        if not download_if_missing:
+            raise OSError("Data not found and `download_if_missing` is False")
+
+        print(f"downloading {len(missing)} and decompressing files for model {model_name}:")
+        with ThreadPoolExecutor(
+            max_workers=min(len(missing), max(cpu_count(), 8))
+        ) as executor:
+            executor.map(download_and_decompress, missing)
+
+    return [str(f) for f in filepaths], filters + skipped_filters
+

--- a/nmma/utils/gitlab.py
+++ b/nmma/utils/gitlab.py
@@ -8,7 +8,7 @@ import requests
 from requests.exceptions import ConnectionError
 from yaml import load
 
-from models_tools import SKIP_FILTERS, download, decompress, get_models_home
+from .models_tools import SKIP_FILTERS, download, decompress, get_models_home
 
 REPO = "https://gitlab.com/Theodlz/nmma-models"
 

--- a/nmma/utils/models.py
+++ b/nmma/utils/models.py
@@ -1,4 +1,5 @@
-from models_tools import SOURCES, get_models_home, get_parser
+from models_tools import SOURCES, get_models_home, get_parser  # noqa
+
 
 def refresh_models_list(models_home=None, source=None):
 
@@ -6,7 +7,7 @@ def refresh_models_list(models_home=None, source=None):
         source = SOURCES[0]
     if source not in ["zenodo", "gitlab"]:
         raise ValueError(f"source must be one of ['gitlab', 'zenodo'], got {source}")
-    
+
     sources_tried = []
     while True:
         try:
@@ -25,6 +26,7 @@ def refresh_models_list(models_home=None, source=None):
                 raise e
             source = remaining_sources[0]
             print(f"Trying to refresh models list from {source} instead")
+
 
 def get_model(
     models_home=None,
@@ -65,6 +67,7 @@ def get_model(
             source = remaining_sources[0]
             print(f"Trying to get model from {source} instead")
 
+
 def main(args=None):
 
     if args is None:
@@ -74,7 +77,9 @@ def main(args=None):
     if args.source is None:
         args.source = SOURCES[0]
     if args.source not in ["zenodo", "gitlab"]:
-        raise ValueError(f"source must be one of ['gitlab', 'zenodo'], got {args.source}")
+        raise ValueError(
+            f"source must be one of ['gitlab', 'zenodo'], got {args.source}"
+        )
 
     refresh = False
     try:
@@ -83,7 +88,8 @@ def main(args=None):
         pass
     if refresh:
         refresh_models_list(
-            models_home=args.svd_path if args.svd_path not in [None, ""] else None, source=args.source
+            models_home=args.svd_path if args.svd_path not in [None, ""] else None,
+            source=args.source,
         )
 
     filters = []
@@ -102,7 +108,7 @@ def main(args=None):
         filters=filters,
         source=args.source,
     )
-        
+
 
 if __name__ == "__main__":
     main()

--- a/nmma/utils/models.py
+++ b/nmma/utils/models.py
@@ -1,4 +1,4 @@
-from models_tools import SOURCES, get_models_home, get_parser  # noqa
+from .models_tools import SOURCES, get_models_home, get_parser  # noqa
 
 
 def refresh_models_list(models_home=None, source=None):

--- a/nmma/utils/models.py
+++ b/nmma/utils/models.py
@@ -15,7 +15,7 @@ def refresh_models_list(models_home=None, source=None):
                 from .gitlab import refresh_models_list
             elif source == "zenodo":
                 from .zenodo import refresh_models_list
-            refresh_models_list(models_home=models_home)
+            models = refresh_models_list(models_home=models_home)
             break
         except Exception as e:
             print(f"Error while refreshing models list from {source}: {str(e)}")
@@ -26,6 +26,8 @@ def refresh_models_list(models_home=None, source=None):
                 raise e
             source = remaining_sources[0]
             print(f"Trying to refresh models list from {source} instead")
+
+    return models
 
 
 def get_model(

--- a/nmma/utils/models.py
+++ b/nmma/utils/models.py
@@ -12,9 +12,9 @@ def refresh_models_list(models_home=None, source=None):
     while True:
         try:
             if source == "gitlab":
-                from gitlab import refresh_models_list
+                from .gitlab import refresh_models_list
             elif source == "zenodo":
-                from zenodo import refresh_models_list
+                from .zenodo import refresh_models_list
             refresh_models_list(models_home=models_home)
             break
         except Exception as e:
@@ -46,9 +46,9 @@ def get_model(
     while True:
         try:
             if source == "gitlab":
-                from gitlab import get_model
+                from .gitlab import get_model
             elif source == "zenodo":
-                from zenodo import get_model
+                from .zenodo import get_model
             get_model(
                 models_home=models_home,
                 model_name=model_name,

--- a/nmma/utils/models.py
+++ b/nmma/utils/models.py
@@ -1,217 +1,30 @@
-import argparse
-import re
-import shutil
-from collections import namedtuple
-from concurrent.futures import ThreadPoolExecutor
-from multiprocessing import cpu_count
-from os import environ, makedirs
-from os.path import exists, expanduser, join
-from pathlib import Path
+from models_tools import SOURCES, get_models_home, get_parser
 
-import requests
-from requests.exceptions import ConnectionError
-from tqdm.auto import tqdm
-from yaml import load
+def refresh_models_list(models_home=None, source=None):
 
-PERMANENT_DOI = "8039909"
-DOI = ""
-MODELS = {}
-
-RemoteFileMetadata = namedtuple("RemoteFileMetadata", ["filename", "url", "checksum"])
-
-pbar = {}
-
-# X-ray and Radio data
-SKIP_FILTERS = [
-    "X-ray-1keV",
-    "X-ray-5keV",
-    "radio-5.5GHz",
-    "radio-1.25GHz",
-    "radio-3GHz",
-    "radio-6GHz",
-]
-
-
-def get_models_home(models_home=None) -> str:
-    if models_home is None:
-        models_home = environ.get("NMMA_MODELS", join("~", "nmma_models"))
-    models_home = expanduser(models_home)
-    if not exists(models_home):
-        makedirs(models_home)
-    return models_home
-
-
-def clear_data_home(models_home=None):
-    models_home = get_models_home(models_home)
-    shutil.rmtree(models_home)
-
-
-def get_latest_zenodo_doi(permanent_doi):
-    headers = {  # we emulate a browser request with a recent chrome version to avoid zenodo blocking us
-        "X-Requested-With": "XMLHttpRequest",
-        "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36",
-        "Accept": "*/*",
-        "Host": "zenodo.org",
-        "Connection": "keep-alive",
-        "Pragma": "no-cache",
-        "Cache-Control": "no-cache",
-    }
-    r = requests.get(
-        f"https://zenodo.org/record/{permanent_doi}",
-        allow_redirects=True,
-        headers=headers,
-    )
-    try:
-        data = r.text.split("10.5281/zenodo.")[1]
-        doi = re.findall(r"^\d+", data)[0]
-    except Exception as e:
-        raise ValueError(f"Could not find latest DOI: {str(e)}")
-    return doi
-
-
-def download(file_info):
-    url, filepath = file_info
-    resp = requests.get(url, stream=True)
-    total = int(resp.headers.get("content-length", 0))
-    chunk_size = 1024
-    file_content = b""
-    with tqdm(
-        total=total,
-        unit="iB",
-        unit_scale=True,
-        unit_divisor=1024,
-        desc=f"{str(filepath).split('/')[-1]}",
-    ) as pbar:
-        for chunk in resp.iter_content(chunk_size=chunk_size):
-            file_content += chunk
-            pbar.update(len(chunk))
-
-    if len(file_content) != total:
-        raise ValueError(
-            f"Downloaded file {filepath} is incomplete. "
-            f"Only {len(file_content)} of {total} bytes were downloaded."
-        )
-    if not exists(Path(filepath).parent):
+    if source is None:
+        source = SOURCES[0]
+    if source not in ["zenodo", "gitlab"]:
+        raise ValueError(f"source must be one of ['gitlab', 'zenodo'], got {source}")
+    
+    sources_tried = []
+    while True:
         try:
-            makedirs(Path(filepath).parent)
-        except Exception:
-            pass
-    with open(filepath, "wb") as f:
-        f.write(file_content)
-
-    return filepath
-
-
-def download_models_list(doi=None, models_home=None):
-    # first we load the models list from zenodo
-    models_home = get_models_home(models_home)
-    if not exists(models_home):
-        makedirs(models_home)
-    r = requests.get(
-        f"https://zenodo.org/record/{doi}/files/models.yaml", allow_redirects=True
-    )
-    with open(Path(models_home, "models.yaml"), "wb") as f:
-        f.write(r.content)
-
-
-def load_models_list(doi=None, models_home=None):
-    # if models.yaml doesn't exist, download it
-    global DOI
-    if DOI in [None, ""]:
-        try:
-            DOI = get_latest_zenodo_doi(PERMANENT_DOI)
-        except Exception:
-            print(
-                "Could not retrieve latest DOI, models won't be downloaded or updated. Will try using existing list or local files available."
-            )
-            DOI = PERMANENT_DOI
-            pass
-
-    if doi in [None, ""]:
-        doi = DOI
-
-    models_home = get_models_home(models_home)
-
-    downloaded_if_missing = True
-    if not exists(Path(models_home, "models.yaml")):
-        try:
-            if doi not in [None, ""]:
-                download_models_list(doi=DOI, models_home=models_home)
-            else:
-                raise ConnectionError("No DOI provided")
-        except ConnectionError:
-            downloaded_if_missing = False
-            pass
-
-    models = {}
-
-    if downloaded_if_missing:
-        try:
-            from yaml import CLoader as Loader
-        except ImportError:
-            from yaml import Loader
-        try:
-            with open(Path(models_home, "models.yaml"), "r") as f:
-                models = load(f, Loader=Loader)
+            if source == "gitlab":
+                from gitlab import refresh_models_list
+            elif source == "zenodo":
+                from zenodo import refresh_models_list
+            refresh_models_list(models_home=models_home)
+            break
         except Exception as e:
-            downloaded_if_missing = False
-            print(
-                f"Could not open the download models list, using local files instead: {str(e)}"
-            )
-
-    if not downloaded_if_missing:
-        print("Attempting to retrieve local files...")
-
-    files = [f for f in Path(models_home).glob("*") if f.is_dir()]
-    files = [f.stem for f in files]
-
-    for f in files:
-        name = f.split("/")[-1]
-        filters = []
-        if exists(Path(models_home, name)):
-            filter_files = [
-                f.stem for f in Path(models_home, name).glob("*") if f.is_file()
-            ]
-            for ff in filter_files:
-                ff = ff.split("/")[-1]
-
-                if name in ff:
-                    ff = ff.replace(name, "")
-
-                if ff.startswith("_"):
-                    ff = ff[1:]
-
-                if ff.endswith("_"):
-                    ff = ff[:-1]
-
-                if ff is not None and ff != "":
-                    filters.append(ff)
-
-        filters = list(set(filters))
-        if name not in models:
-            models[name] = {"filters": filters}
-        elif "filters" not in models[name]:
-            models[name]["filters"] = filters
-        else:
-            models[name]["filters"] = list(set(filters + models[name]["filters"]))
-
-    return models, downloaded_if_missing is False
-
-
-def refresh_models_list(models_home=None):
-    global DOI
-    global MODELS
-    models_home = get_models_home(models_home)
-    if exists(Path(models_home, "models.yaml")):
-        Path(models_home, "models.yaml").unlink()
-    models = MODELS
-    try:
-        models = load_models_list(DOI, models_home)[0]
-        MODELS = models
-    except Exception as e:
-        raise ValueError(f"Could not load models list: {str(e)}")
-    return models
-
+            print(f"Error while refreshing models list from {source}: {str(e)}")
+            sources_tried.append(source)
+            remaining_sources = [s for s in SOURCES if s not in sources_tried]
+            if len(remaining_sources) == 0:
+                print("No more sources to try, exiting")
+                raise e
+            source = remaining_sources[0]
+            print(f"Trying to refresh models list from {source} instead")
 
 def get_model(
     models_home=None,
@@ -219,132 +32,49 @@ def get_model(
     filters=[],
     download_if_missing=True,
     filters_only=False,
+    source=None,
 ):
-    global DOI
-    global MODELS
 
-    models_home = get_models_home(models_home)
-    used_local = False
-    try:
-        MODELS, used_local = load_models_list(DOI, models_home)
-    except Exception as e:
-        raise ValueError(f"Could not load models list: {str(e)}")
+    if source is None:
+        source = SOURCES[0]
+    if source not in ["zenodo", "gitlab"]:
+        raise ValueError(f"source must be one of ['gitlab', 'zenodo'], got {source}")
 
-    if used_local:
-        print("Could not access Zenodo, used local models list instead.")
-
-    base_url = f"https://zenodo.org/record/{DOI}/files"
-    if model_name is None:
-        raise ValueError("model_name must be specified, got None")
-    if model_name not in MODELS:
-        raise ValueError(f"model_name {model_name} not found in models list")
-    model_info = MODELS[model_name]
-
-    if not exists(models_home):
-        makedirs(models_home)
-    if not exists(Path(models_home, model_name)):
-        makedirs(Path(models_home, model_name))
-
-    filter_synonyms = [filt.replace("_", ":") for filt in model_info["filters"]]
-
-    all_filters = list(set(model_info["filters"] + filter_synonyms))
-    if filters in [[], None, ""] and "filters" in model_info:
-        filters = model_info["filters"]
-
-    skipped_filters = [f for f in filters if f in SKIP_FILTERS]
-
-    # remove the skip_filters list from the filters
-    filters = [f for f in filters if f not in SKIP_FILTERS]
-
-    missing_filters = list(set(filters).difference(set(all_filters)))
-    if len(missing_filters) > 0:
-        if used_local:
-            raise ValueError(
-                f"local models list does not have filters {','.join(missing_filters)} for {model_name}"
+    sources_tried = []
+    while True:
+        try:
+            if source == "gitlab":
+                from gitlab import get_model
+            elif source == "zenodo":
+                from zenodo import get_model
+            get_model(
+                models_home=models_home,
+                model_name=model_name,
+                filters=filters,
+                download_if_missing=download_if_missing,
+                filters_only=filters_only,
             )
-        else:
-            raise ValueError(
-                f'models list from zenodo does not have filters {",".join(missing_filters)} for {model_name}'
-            )
-
-    core_format = "pkl"
-    filter_format = "pkl"
-    if "_tf" in model_name:
-        filter_format = "h5"
-
-    # Some models have underscores. Keep those, but drop '_tf' if it exists
-    model_name_components = model_name.split("_")
-    if "tf" in model_name_components:
-        model_name_components.remove("tf")
-    core_model_name = "_".join(model_name_components)
-
-    filepaths = (
-        [Path(models_home, f"{core_model_name}.{core_format}")]
-        if not filters_only
-        else []
-    ) + [Path(models_home, model_name, f"{f}.{filter_format}") for f in filters]
-    urls = (
-        [f"{base_url}/{core_model_name}.{core_format}?download=1"]
-        if not filters_only
-        else []
-    ) + [f"{base_url}/{model_name}_{f}.{filter_format}?download=1" for f in filters]
-
-    missing = [(u, f) for u, f in zip(urls, filepaths) if not f.exists()]
-    if len(missing) > 0:
-        if not download_if_missing:
-            raise OSError("Data not found and `download_if_missing` is False")
-        if DOI in [None, ""]:
-            print(
-                f"Could not connect to ZENODO, and no local files found in `{models_home}`. Can't download missing models:"
-            )
-            for u, f in missing:
-                print(f"    - {f}")
-            raise OSError(
-                "Data not found locally and no access to Zenodo. Can't download missing models."
-            )
-
-        print(f"downloading {len(missing)} files for model {model_name}:")
-        with ThreadPoolExecutor(
-            max_workers=min(len(missing), max(cpu_count(), 8))
-        ) as executor:
-            executor.map(download, missing)
-
-    return [str(f) for f in filepaths], filters + skipped_filters
-
-
-def get_parser():
-
-    parser = argparse.ArgumentParser(
-        description="Download SVD models from Zenodo",
-    )
-    parser.add_argument(
-        "--model", type=str, required=True, help="Name the model to be used"
-    )
-    parser.add_argument(
-        "--svd-path",
-        type=str,
-        help="Path to the SVD models directory. If not provided, will use the default path",
-    )
-    parser.add_argument(
-        "--filters",
-        type=str,
-        help="A comma seperated list of filters to use (e.g. g,r,i). If none is provided, will use all the filters available",
-    )
-    parser.add_argument(
-        "--refresh-models-list",
-        type=bool,
-        default=False,
-        help="Refresh the list of models available on Zenodo",
-    )
-
-    return parser
-
+            break
+        except Exception as e:
+            print(f"Error while getting model from {source}: {str(e)}")
+            sources_tried.append(source)
+            remaining_sources = [s for s in SOURCES if s not in sources_tried]
+            if len(remaining_sources) == 0:
+                print("No more sources to try, exiting")
+                raise e
+            source = remaining_sources[0]
+            print(f"Trying to get model from {source} instead")
 
 def main(args=None):
 
     if args is None:
         parser = get_parser()
         args = parser.parse_args()
+
+    if args.source is None:
+        args.source = SOURCES[0]
+    if args.source not in ["zenodo", "gitlab"]:
+        raise ValueError(f"source must be one of ['gitlab', 'zenodo'], got {args.source}")
 
     refresh = False
     try:
@@ -353,7 +83,7 @@ def main(args=None):
         pass
     if refresh:
         refresh_models_list(
-            models_home=args.svd_path if args.svd_path not in [None, ""] else None
+            models_home=args.svd_path if args.svd_path not in [None, ""] else None, source=args.source
         )
 
     filters = []
@@ -370,11 +100,11 @@ def main(args=None):
         models_home=args.svd_path if args.svd_path not in [None, ""] else None,
         model_name=args.model,
         filters=filters,
+        source=args.source,
     )
-
-    # example:
-    # python nmma/utils/models.py --model="Bu2019lm" --filters=ztfr,ztfg,ztfi --svd-path='./svdmodels'
-
+        
 
 if __name__ == "__main__":
     main()
+
+# python nmma/utils/models.py --model="Bu2019lm" --filters=ztfr,ztfg,ztfi --svd-path='./svdmodels' --source='gitlab'

--- a/nmma/utils/models.py
+++ b/nmma/utils/models.py
@@ -49,7 +49,8 @@ def get_model(
                 from .gitlab import get_model
             elif source == "zenodo":
                 from .zenodo import get_model
-            get_model(
+
+            files, filters = get_model(
                 models_home=models_home,
                 model_name=model_name,
                 filters=filters,
@@ -66,6 +67,8 @@ def get_model(
                 raise e
             source = remaining_sources[0]
             print(f"Trying to get model from {source} instead")
+
+    return files, filters
 
 
 def main(args=None):

--- a/nmma/utils/models_tools.py
+++ b/nmma/utils/models_tools.py
@@ -69,19 +69,21 @@ def download(file_info):
 
     return filepath
 
+
 def decompress(file_path):
     if not file_path.endswith(".lzma"):
         raise ValueError(f"File {file_path} is not a .lzma file")
     if not exists(file_path):
         raise ValueError(f"File {file_path} does not exist")
-    
+
     stdout, stderr = subprocess.Popen(
         ["lzma", "-d", file_path], stdout=subprocess.PIPE, stderr=subprocess.PIPE
     ).communicate()
-    if stderr.decode('utf-8') != '' and 'File exists' not in stderr.decode('utf-8'):
-            raise RuntimeError(f'Error decompressing {file_path}: {stderr}')
+    if stderr.decode("utf-8") != "" and "File exists" not in stderr.decode("utf-8"):
+        raise RuntimeError(f"Error decompressing {file_path}: {stderr}")
     return file_path
-    
+
+
 def get_parser():
 
     parser = argparse.ArgumentParser(
@@ -114,4 +116,3 @@ def get_parser():
     )
 
     return parser
-

--- a/nmma/utils/models_tools.py
+++ b/nmma/utils/models_tools.py
@@ -1,0 +1,117 @@
+import argparse
+import shutil
+from os import environ, makedirs
+from os.path import exists, expanduser, join
+from pathlib import Path
+import subprocess
+
+import requests
+from tqdm.auto import tqdm
+
+pbar = {}
+
+SOURCES = ["gitlab", "zenodo"]
+
+# X-ray and Radio data
+SKIP_FILTERS = [
+    "X-ray-1keV",
+    "X-ray-5keV",
+    "radio-5.5GHz",
+    "radio-1.25GHz",
+    "radio-3GHz",
+    "radio-6GHz",
+]
+
+
+def get_models_home(models_home=None) -> str:
+    if models_home is None:
+        models_home = environ.get("NMMA_MODELS", join("~", "nmma_models"))
+    models_home = expanduser(models_home)
+    if not exists(models_home):
+        makedirs(models_home)
+    return models_home
+
+
+def clear_data_home(models_home=None):
+    models_home = get_models_home(models_home)
+    shutil.rmtree(models_home)
+
+
+def download(file_info):
+    url, filepath = file_info
+    resp = requests.get(url, stream=True)
+    total = int(resp.headers.get("content-length", 0))
+    chunk_size = 1024
+    file_content = b""
+    with tqdm(
+        total=total,
+        unit="iB",
+        unit_scale=True,
+        unit_divisor=1024,
+        desc=f"{str(filepath).split('/')[-1]}",
+    ) as pbar:
+        for chunk in resp.iter_content(chunk_size=chunk_size):
+            file_content += chunk
+            pbar.update(len(chunk))
+
+    if len(file_content) != total:
+        raise ValueError(
+            f"Downloaded file {filepath} is incomplete. "
+            f"Only {len(file_content)} of {total} bytes were downloaded."
+        )
+    if not exists(Path(filepath).parent):
+        try:
+            makedirs(Path(filepath).parent)
+        except Exception:
+            pass
+    with open(filepath, "wb") as f:
+        f.write(file_content)
+
+    return filepath
+
+def decompress(file_path):
+    if not file_path.endswith(".lzma"):
+        raise ValueError(f"File {file_path} is not a .lzma file")
+    if not exists(file_path):
+        raise ValueError(f"File {file_path} does not exist")
+    
+    stdout, stderr = subprocess.Popen(
+        ["lzma", "-d", file_path], stdout=subprocess.PIPE, stderr=subprocess.PIPE
+    ).communicate()
+    if stderr.decode('utf-8') != '' and 'File exists' not in stderr.decode('utf-8'):
+            raise RuntimeError(f'Error decompressing {file_path}: {stderr}')
+    return file_path
+    
+def get_parser():
+
+    parser = argparse.ArgumentParser(
+        description="Download SVD models from GitLab or Zenodo"
+    )
+    parser.add_argument(
+        "--model", type=str, required=True, help="Name the model to be used"
+    )
+    parser.add_argument(
+        "--svd-path",
+        type=str,
+        help="Path to the SVD models directory. If not provided, will use the default path",
+    )
+    parser.add_argument(
+        "--filters",
+        type=str,
+        help="A comma seperated list of filters to use (e.g. g,r,i). If none is provided, will use all the filters available",
+    )
+    parser.add_argument(
+        "--refresh-models-list",
+        type=bool,
+        default=False,
+        help="Refresh the list of models available on Zenodo",
+    )
+    parser.add_argument(
+        "--source",
+        type=str,
+        default="gitlab",
+        help="Source of the models list. Must be one of ['zenodo', 'gitlab']. Default is 'gitlab'",
+    )
+
+    return parser
+

--- a/nmma/utils/zenodo.py
+++ b/nmma/utils/zenodo.py
@@ -9,12 +9,11 @@ import requests
 from requests.exceptions import ConnectionError
 from yaml import load
 
-from models_tools import *
+from models_tools import SKIP_FILTERS, download, get_models_home
 
 PERMANENT_DOI = "8039909"
 DOI = ""
 MODELS = {}
-
 
 
 def get_latest_zenodo_doi(permanent_doi):
@@ -38,6 +37,7 @@ def get_latest_zenodo_doi(permanent_doi):
     except Exception as e:
         raise ValueError(f"Could not find latest DOI: {str(e)}")
     return doi
+
 
 def download_models_list(doi=None, models_home=None):
     # first we load the models list from zenodo

--- a/nmma/utils/zenodo.py
+++ b/nmma/utils/zenodo.py
@@ -1,0 +1,249 @@
+import re
+from concurrent.futures import ThreadPoolExecutor
+from multiprocessing import cpu_count
+from os.path import exists
+from pathlib import Path
+from os import makedirs
+
+import requests
+from requests.exceptions import ConnectionError
+from yaml import load
+
+from models_tools import *
+
+PERMANENT_DOI = "8039909"
+DOI = ""
+MODELS = {}
+
+
+
+def get_latest_zenodo_doi(permanent_doi):
+    headers = {  # we emulate a browser request with a recent chrome version to avoid zenodo blocking us
+        "X-Requested-With": "XMLHttpRequest",
+        "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36",
+        "Accept": "*/*",
+        "Host": "zenodo.org",
+        "Connection": "keep-alive",
+        "Pragma": "no-cache",
+        "Cache-Control": "no-cache",
+    }
+    r = requests.get(
+        f"https://zenodo.org/record/{permanent_doi}",
+        allow_redirects=True,
+        headers=headers,
+    )
+    try:
+        data = r.text.split("10.5281/zenodo.")[1]
+        doi = re.findall(r"^\d+", data)[0]
+    except Exception as e:
+        raise ValueError(f"Could not find latest DOI: {str(e)}")
+    return doi
+
+def download_models_list(doi=None, models_home=None):
+    # first we load the models list from zenodo
+    models_home = get_models_home(models_home)
+    if not exists(models_home):
+        makedirs(models_home)
+    r = requests.get(
+        f"https://zenodo.org/record/{doi}/files/models.yaml", allow_redirects=True
+    )
+    with open(Path(models_home, "models.yaml"), "wb") as f:
+        f.write(r.content)
+
+
+def load_models_list(doi=None, models_home=None):
+    # if models.yaml doesn't exist, download it
+    global DOI
+    if DOI in [None, ""]:
+        try:
+            DOI = get_latest_zenodo_doi(PERMANENT_DOI)
+        except Exception:
+            print(
+                "Could not retrieve latest DOI, models won't be downloaded or updated. Will try using existing list or local files available."
+            )
+            DOI = PERMANENT_DOI
+            pass
+
+    if doi in [None, ""]:
+        doi = DOI
+
+    models_home = get_models_home(models_home)
+
+    downloaded_if_missing = True
+    if not exists(Path(models_home, "models.yaml")):
+        try:
+            if doi not in [None, ""]:
+                download_models_list(doi=DOI, models_home=models_home)
+            else:
+                raise ConnectionError("No DOI provided")
+        except ConnectionError:
+            downloaded_if_missing = False
+            pass
+
+    models = {}
+
+    if downloaded_if_missing:
+        try:
+            from yaml import CLoader as Loader
+        except ImportError:
+            from yaml import Loader
+        try:
+            with open(Path(models_home, "models.yaml"), "r") as f:
+                models = load(f, Loader=Loader)
+        except Exception as e:
+            downloaded_if_missing = False
+            print(
+                f"Could not open the download models list, using local files instead: {str(e)}"
+            )
+
+    if not downloaded_if_missing:
+        print("Attempting to retrieve local files...")
+
+    files = [f for f in Path(models_home).glob("*") if f.is_dir()]
+    files = [f.stem for f in files]
+
+    for f in files:
+        name = f.split("/")[-1]
+        filters = []
+        if exists(Path(models_home, name)):
+            filter_files = [
+                f.stem for f in Path(models_home, name).glob("*") if f.is_file()
+            ]
+            for ff in filter_files:
+                ff = ff.split("/")[-1]
+
+                if name in ff:
+                    ff = ff.replace(name, "")
+
+                if ff.startswith("_"):
+                    ff = ff[1:]
+
+                if ff.endswith("_"):
+                    ff = ff[:-1]
+
+                if ff is not None and ff != "":
+                    filters.append(ff)
+
+        filters = list(set(filters))
+        if name not in models:
+            models[name] = {"filters": filters}
+        elif "filters" not in models[name]:
+            models[name]["filters"] = filters
+        else:
+            models[name]["filters"] = list(set(filters + models[name]["filters"]))
+
+    return models, downloaded_if_missing is False
+
+
+def refresh_models_list(models_home=None):
+    global DOI
+    global MODELS
+    models_home = get_models_home(models_home)
+    if exists(Path(models_home, "models.yaml")):
+        Path(models_home, "models.yaml").unlink()
+    models = MODELS
+    try:
+        models = load_models_list(DOI, models_home)[0]
+        MODELS = models
+    except Exception as e:
+        raise ValueError(f"Could not load models list: {str(e)}")
+    return models
+
+
+def get_model(
+    models_home=None,
+    model_name=None,
+    filters=[],
+    download_if_missing=True,
+    filters_only=False,
+):
+    global DOI
+    global MODELS
+
+    models_home = get_models_home(models_home)
+    used_local = False
+    try:
+        MODELS, used_local = load_models_list(DOI, models_home)
+    except Exception as e:
+        raise ValueError(f"Could not load models list: {str(e)}")
+
+    if used_local:
+        print("Could not access Zenodo, used local models list instead.")
+
+    base_url = f"https://zenodo.org/record/{DOI}/files"
+    if model_name is None:
+        raise ValueError("model_name must be specified, got None")
+    if model_name not in MODELS:
+        raise ValueError(f"model_name {model_name} not found in models list")
+    model_info = MODELS[model_name]
+
+    if not exists(models_home):
+        makedirs(models_home)
+    if not exists(Path(models_home, model_name)):
+        makedirs(Path(models_home, model_name))
+
+    filter_synonyms = [filt.replace("_", ":") for filt in model_info["filters"]]
+
+    all_filters = list(set(model_info["filters"] + filter_synonyms))
+    if filters in [[], None, ""] and "filters" in model_info:
+        filters = model_info["filters"]
+
+    skipped_filters = [f for f in filters if f in SKIP_FILTERS]
+
+    # remove the skip_filters list from the filters
+    filters = [f for f in filters if f not in SKIP_FILTERS]
+
+    missing_filters = list(set(filters).difference(set(all_filters)))
+    if len(missing_filters) > 0:
+        if used_local:
+            raise ValueError(
+                f"local models list does not have filters {','.join(missing_filters)} for {model_name}"
+            )
+        else:
+            raise ValueError(
+                f'models list from zenodo does not have filters {",".join(missing_filters)} for {model_name}'
+            )
+
+    core_format = "pkl"
+    filter_format = "pkl"
+    if "_tf" in model_name:
+        filter_format = "h5"
+
+    # Some models have underscores. Keep those, but drop '_tf' if it exists
+    model_name_components = model_name.split("_")
+    if "tf" in model_name_components:
+        model_name_components.remove("tf")
+    core_model_name = "_".join(model_name_components)
+
+    filepaths = (
+        [Path(models_home, f"{core_model_name}.{core_format}")]
+        if not filters_only
+        else []
+    ) + [Path(models_home, model_name, f"{f}.{filter_format}") for f in filters]
+    urls = (
+        [f"{base_url}/{core_model_name}.{core_format}?download=1"]
+        if not filters_only
+        else []
+    ) + [f"{base_url}/{model_name}_{f}.{filter_format}?download=1" for f in filters]
+
+    missing = [(u, f) for u, f in zip(urls, filepaths) if not f.exists()]
+    if len(missing) > 0:
+        if not download_if_missing:
+            raise OSError("Data not found and `download_if_missing` is False")
+        if DOI in [None, ""]:
+            print(
+                f"Could not connect to ZENODO, and no local files found in `{models_home}`. Can't download missing models:"
+            )
+            for u, f in missing:
+                print(f"    - {f}")
+            raise OSError(
+                "Data not found locally and no access to Zenodo. Can't download missing models."
+            )
+
+        print(f"downloading {len(missing)} files for model {model_name}:")
+        with ThreadPoolExecutor(
+            max_workers=min(len(missing), max(cpu_count(), 8))
+        ) as executor:
+            executor.map(download, missing)
+
+    return [str(f) for f in filepaths], filters + skipped_filters

--- a/nmma/utils/zenodo.py
+++ b/nmma/utils/zenodo.py
@@ -9,7 +9,7 @@ import requests
 from requests.exceptions import ConnectionError
 from yaml import load
 
-from models_tools import SKIP_FILTERS, download, get_models_home
+from .models_tools import SKIP_FILTERS, download, get_models_home
 
 PERMANENT_DOI = "8039909"
 DOI = ""


### PR DESCRIPTION
This PR makes it possible to point either to gitlab or zenodo to fetch the models.

We make gitlab the default, as this is the one we are able to actively update. Also, we make sure that a failure to use one source of models triggers a retry with another source, until we run out of options. Here we have just 2 of them, but we can imagine having multiple ones in the future.

Maybe, later on, we'll want to have the models.yaml file live in a seperate repo or NMMA itself, and have a pointer to each source for each models, to have a more robust system. Something to think about.


For context, we opted for gitlab to bypass the very strict upload and bandwidth limits imposed by github when using git lfs (a module that allows for the upload of large binary files). Here's the gitlab repo: https://gitlab.com/Theodlz/nmma-models. There, we make use of compression to reduce the individual file size. This should help with downloading speeds, as well as maintaining the repo's full size small enough.

Also added some tests to improve the coverage a little bit :)