### PR TITLE
Add notebook requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ p_tqdm
 ultranest
 tornado
 tensorflow
+notebook


### PR DESCRIPTION
This PR adds `notebook` as a requirement for NMMA, since the repo has some jupyter notebooks used to explain certain features.