### PR TITLE
Add support for user-specified filters in API analyses

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -92,11 +92,18 @@ def run_nmma_model(data_dict):
     tmin = analysis_parameters.get("tmin")
     tmax = analysis_parameters.get("tmax")
     dt = analysis_parameters.get("dt")
+    filters = analysis_parameters.get("filters (comma-separated)")
     nlive = analysis_parameters.get("nlive")
     error_budget = analysis_parameters.get("error_budget")
     Ebv_max = analysis_parameters.get("Ebv_max")
     interpolation_type = analysis_parameters.get("interpolation-type")
     sampler = analysis_parameters.get("sampler")
+
+    if "all" in filters:
+        filter_arg = None
+    else:
+        filter_list = [x.strip() for x in filters.split(",")]
+        filter_arg = ",".join(filter_list)
 
     # this example analysis service expects the photometry to be in
     # a csv file (at data_dict["inputs"]["photometry"]) with the following columns
@@ -210,6 +217,8 @@ def run_nmma_model(data_dict):
             interpolation_type,
             "--sampler",
             sampler,
+            "--filters",
+            filter_arg,
             "--plot",
         ]
 

--- a/nmma/em/analysis.py
+++ b/nmma/em/analysis.py
@@ -421,6 +421,9 @@ def analysis(args):
         sample_times = np.arange(args.tmin, args.tmax + args.dt, args.dt)
     print("Creating light curve model for inference")
 
+    if args.filters == "None":
+        args.filters = None
+
     if args.filters:
         filters = args.filters.split(",")
     else:

--- a/tools/analysis_slurm.py
+++ b/tools/analysis_slurm.py
@@ -124,6 +124,7 @@ def main(args=None):
         "tmin": "$TMIN",
         "tmax": "$TMAX",
         "dt": "$DT",
+        "filters": "$FILTERS",
         "skip_sampling": "$SKIP_SAMPLING",
     }
 
@@ -136,6 +137,7 @@ def main(args=None):
         "tmin",
         "tmax",
         "dt",
+        "filters",
     ]
     wildcard_boolean_keys = ["skip_sampling"]
 


### PR DESCRIPTION
This PR adds support for a list of filters to be passed to the API for analysis. The local API is modified here, along with the code to generate a slurm script for Expanse/HPC resources. Additionally, a two-line change to `analysis.py` ensures that the code will behave as expected if the string `"None"` (rather than `None`) is given to the `--filters` argument.

A companion PR to `nmma-api` (https://github.com/Theodlz/nmma-api/pull/13) adds compatibility for user-specified filters.