### PR TITLE
Require scipy < 1.10

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ bilby_pipe>=1.1.0
 colorcet
 numpy>=1.9
 matplotlib>=2.0,<3.8
-scipy>=1.7.1
+scipy>=1.7.1,<1.10
 pandas>=1.3.4,<2.0
 astropy>=4.3.1
 scikit-learn>=1.0.2,<1.2


### PR DESCRIPTION
This PR restricts scipy to < 1.10 in light of installation issues encountered with that version.