### PR TITLE
Require scipy >= 1.10

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ bilby_pipe>=1.1.0
 colorcet
 numpy>=1.9
 matplotlib>=2.0,<3.8
-scipy>=1.7.1,<1.10
+scipy>=1.10
 pandas>=1.3.4,<2.0
 astropy>=4.3.1
 scikit-learn>=1.0.2,<1.2


### PR DESCRIPTION
This PR requires scipy >= 1.10, since prior versions have a memory leak vulnerability:

![image](https://github.com/nuclear-multimessenger-astronomy/nmma/assets/42810347/a3a4fe45-11fd-42f6-8d88-297c7c1c7427)
