### PR TITLE
Remove 'old-style' _mag model code

### DIFF
--- a/nmma/em/model.py
+++ b/nmma/em/model.py
@@ -258,25 +258,12 @@ class SVDLightCurveModel(object):
                             self.svd_mag_model[filt]["gps"] = pickle.load(handle)
                 self.svd_lbol_model = None
             else:
-                # Try old style request
-                mag_modelfile = os.path.join(self.svd_path, "{0}_mag.pkl".format(model))
-                with open(mag_modelfile, "rb") as handle:
-                    self.svd_mag_model = pickle.load(handle)
-
-                outdir = mag_modelfile.replace(".pkl", "")
-                for filt in self.filters:
-                    outfile = os.path.join(outdir, f"{filt}.pkl")
-                    if not os.path.isfile(outfile):
-                        print(f"Could not find model file for filter {filt}")
-                    else:
-                        print(f"Loaded filter {filt}")
-                        with open(outfile, "rb") as handle:
-                            self.svd_mag_model[filt]["gps"] = pickle.load(handle)
-                lbol_modelfile = os.path.join(
-                    self.svd_path, "{0}_lbol.pkl".format(model)
-                )
-                with open(lbol_modelfile, "rb") as handle:
-                    self.svd_lbol_model = pickle.load(handle)
+                if local_only:
+                    raise ValueError(
+                        f"Model file not found: {modelfile}\n If possible, try removing the --local-only flag and rerunning."
+                    )
+                else:
+                    raise ValueError(f"Model file not found: {modelfile}")
         elif self.interpolation_type == "api_gp":
             from .training import load_api_gp_model
 
@@ -322,38 +309,12 @@ class SVDLightCurveModel(object):
                         self.svd_mag_model[filt]["model"] = load_model(outfile)
                 self.svd_lbol_model = None
             else:
-                _, model_filters = get_model(
-                    self.svd_path, f"{self.model}_mag_tf", filters=filters
-                )
-                if filters is None and model_filters is not None:
-                    self.filters = model_filters
-
-                mag_modelfile = os.path.join(
-                    self.svd_path, "{0}_mag_tf.pkl".format(model)
-                )
-                with open(mag_modelfile, "rb") as handle:
-                    self.svd_mag_model = pickle.load(handle)
-
-                if self.filters is None:
-                    self.filters = list(self.svd_mag_model.keys())
-
-                outdir = mag_modelfile.replace(".pkl", "")
-                for filt in self.filters:
-                    outfile = os.path.join(outdir, f"{filt}.h5")
-                    self.svd_mag_model[filt]["model"] = load_model(outfile)
-
-                get_model(
-                    self.svd_path, f"{self.model}_lbol_tf", self.svd_mag_model.keys()
-                )
-                lbol_modelfile = os.path.join(
-                    self.svd_path, "{0}_lbol_tf.pkl".format(model)
-                )
-                with open(lbol_modelfile, "rb") as handle:
-                    self.svd_lbol_model = pickle.load(handle)
-
-                outdir = lbol_modelfile.replace(".pkl", "")
-                outfile = os.path.join(outdir, "model.h5")
-                self.svd_lbol_model["model"] = load_model(outfile)
+                if local_only:
+                    raise ValueError(
+                        f"Model file not found: {modelfile}\n If possible, try removing the --local-only flag and rerunning."
+                    )
+                else:
+                    raise ValueError(f"Model file not found: {modelfile}")
         else:
             return ValueError("--interpolation-type must be sklearn_gp or tensorflow")
 


### PR DESCRIPTION
This PR removes code in `em/model.py` that loads deprecated models of the form `..._mag` and `..._lbol`.

The removed code tends to raise an error message about these deprecated formats when a newer model cannot be found, which can be confusing since the user is typically not trying to load the older model format. This error message has been replaced with more helpful ones describing the code's failure to load a model using the `modelfile` path.