### PR TITLE
Add tool to convert skyportal lightcurves to nmma format

### DIFF
--- a/doc/data_inj_obs.md
+++ b/doc/data_inj_obs.md
@@ -72,3 +72,12 @@ Example: AT2017gfo data excerpt
     2017-08-18T18:11:31.200 2massk 17.91000 0.05000
 
 The first column represents the ISOT time, followed by the filter or spectral band in the second column, the measured AB magnitude and its respective error are given in the third and fourth column. This data structure detailed above is also applicable for other astrophysical sources (SNe, GRBs) or models implemented in NMMA.
+
+Example: transient data downloaded from [SkyPortal](https://github.com/skyportal/skyportal)/fritz:
+
+    "id","mjd","mag","magerr","limiting_mag","filter","instrument_name","instrument_id","snr","magsys","origin","altdata","ra","dec","ra_unc","dec_unc","created_at","annotations","owner","Edit","Delete"
+    "518817455","60257.28104169993","","","19.30739974975586","ztfr","ZTF","1","","ab","None","","","","","","2023-12-07T05:49:42.369500","","[object Object]","",""
+    "518817456","60257.282500000205","","","19.347900390625","ztfr","ZTF","1","","ab","None","","","","","","2023-12-07T05:49:42.369555","","[object Object]","",""
+    "518817457","60257.36459490005","","","20.112499237060547","ztfg","ZTF","1","","ab","None","","","","","","2023-12-07T05:49:42.369574","","[object Object]","",""
+
+Data downloaded from a source's photometry table on SkyPortal take the comma-separated format above. These files must be converted to NMMA format (see first example above) before running analyses. Run `tools/convert_skyportal_lcs.py --filepath <path/to/lcs.csv>` to perform the conversion.

--- a/tools/convert_skyportal_lcs.py
+++ b/tools/convert_skyportal_lcs.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python
+from astropy.table import Table
+import numpy as np
+from astropy.time import Time
+import pathlib
+import argparse
+
+BASE_DIR = pathlib.Path(__file__).parent.parent.absolute()
+
+
+def main(
+    filepath,
+):
+    data_path = BASE_DIR / filepath
+    try:
+        data = Table.read(data_path, format="ascii.csv", header_start=1)
+    except Exception as e:
+        raise ValueError(f"input data is not in the expected format {e}")
+
+    try:
+        local_data_path = str(data_path.with_suffix(".dat"))
+        with open(local_data_path, "w") as f:
+            # output the data in the format desired by NMMA:
+            # remove rows where mag and magerr are missing, or not float, or negative
+            data = data[
+                np.isfinite(data["mag"])
+                & np.isfinite(data["magerr"])
+                & (data["mag"] > 0)
+                & (data["magerr"] > 0)
+            ]
+            for row in data:
+                tt = Time(row["mjd"], format="mjd").isot
+                filt = row["filter"]
+                mag = row["mag"]
+                magerr = row["magerr"]
+                f.write(f"{tt} {filt} {mag} {magerr}\n")
+        print(f"Wrote reformatted lightcurve to {local_data_path}")
+    except Exception as e:
+        raise ValueError(f"failed to format data {e}")
+
+
+def get_parser():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--filepath",
+        type=str,
+        required=True,
+        help="path/name of lightcurve file (including extension) within base nmma directory",
+    )
+
+    return parser
+
+
+if __name__ == "__main__":
+    parser = get_parser()
+    args = parser.parse_args()
+    main(**vars(args))

--- a/tools/convert_skyportal_lcs.py
+++ b/tools/convert_skyportal_lcs.py
@@ -17,9 +17,6 @@ def main(
     except Exception as e:
         raise ValueError(f"input data is not in the expected format {e}")
 
-    import code
-
-    code.interact(local=locals())
     try:
         local_data_path = str(data_path.with_suffix(".dat"))
         with open(local_data_path, "w") as f:

--- a/tools/convert_skyportal_lcs.py
+++ b/tools/convert_skyportal_lcs.py
@@ -13,10 +13,13 @@ def main(
 ):
     data_path = BASE_DIR / filepath
     try:
-        data = Table.read(data_path, format="ascii.csv", header_start=1)
+        data = Table.read(data_path, format="ascii.csv")
     except Exception as e:
         raise ValueError(f"input data is not in the expected format {e}")
 
+    import code
+
+    code.interact(local=locals())
     try:
         local_data_path = str(data_path.with_suffix(".dat"))
         with open(local_data_path, "w") as f:


### PR DESCRIPTION
This PR adds a tool to convert light curves downloaded from the skyportal/fritz frontend to NMMA format. Also, the Injections & observational data documentation is updated with an example lightcurve downloaded from SkyPortal.