### PR TITLE
Enhancements for EM Counterpart Detection and Bandpass Interpolation (sncosmo)

### DIFF
--- a/nmma/em/create_lightcurves.py
+++ b/nmma/em/create_lightcurves.py
@@ -203,9 +203,9 @@ def get_parser():
     parser.add_argument(
         "--ylim",
         type=str,
-        default="22,16",
+        default="-12,-18",
         nargs="*",
-        help="Upper and lower magnitude limit for light curve plot (default: 22-16)",
+        help="Upper and lower magnitude limit for light curve plot (default: -12,-18)",
     )
     parser.add_argument(
         "--photometric-error-budget",
@@ -400,7 +400,7 @@ def main(args=None):
             "ytick.labelsize": 42,
             "text.usetex": True,
             "font.family": "Times New Roman",
-            "figure.figsize": [16, 20],
+            "figure.figsize": [18, 25],
         }
         matplotlib.rcParams.update(params)
 
@@ -410,8 +410,9 @@ def main(args=None):
 
         fig = plt.figure()
 
-        filts = list(set(mag_ds[index].keys()).difference({"t"}))
-
+        #filts = list(set(mag_ds[index].keys()).difference({"t"}))
+        filts = filters
+        
         ncols = 1
         nrows = int(np.ceil(len(filts) / ncols))
         gs = fig.add_gridspec(nrows=nrows, ncols=ncols, wspace=0.6, hspace=0.5)
@@ -466,7 +467,8 @@ def main(args=None):
             ylim = [float(x) for x in ylim]
             plt.ylim(ylim)
 
-            ax.set_ylabel(filt, fontsize=30, rotation=0, labelpad=14)
+            #ax.set_ylabel(filt, fontsize=30, rotation=0, labelpad=14)
+            ax.set_ylabel(filt, fontsize=30, rotation=90, labelpad=8)
 
             if ii == len(filts) - 1:
                 ax.set_xticks([np.ceil(x) for x in np.linspace(xlim[0], xlim[1], 8)])
@@ -474,8 +476,8 @@ def main(args=None):
                 plt.setp(ax.get_xticklabels(), visible=False)
 
             ax.set_yticks([np.ceil(x) for x in np.linspace(ylim[0], ylim[1], 8)])
-            ax.tick_params(axis="x", labelsize=42)
-            ax.tick_params(axis="y", labelsize=42)
+            ax.tick_params(axis="x", labelsize=35)
+            ax.tick_params(axis="y", labelsize=35)
             ax.grid(which="both", alpha=0.5)
 
             axs.append(ax)
@@ -483,12 +485,12 @@ def main(args=None):
         fig.colorbar(c, ax=axs, location="right", shrink=0.6)
         fig.text(0.4, 0.05, r"Time [days]", fontsize=42)
         fig.text(
-            0.01,
+            0.001,
             0.5,
             r"Absolute Magnitude",
             va="center",
             rotation="vertical",
-            fontsize=42,
+            fontsize=35,
         )
 
         # plt.tight_layout()

--- a/nmma/em/detect_lightcurves.py
+++ b/nmma/em/detect_lightcurves.py
@@ -62,12 +62,6 @@ def main():
         help="Either BNS or NSBH"
     )
     parser.add_argument(
-        "-c", 
-        "--configDirectory",
-        help="gwemopt config file directory.", 
-        required=False
-    )
-    parser.add_argument(
         "--outdir", 
         type=str, 
         default="outdir",
@@ -192,10 +186,10 @@ def main():
         )
 
         if args.telescope.lower() == 'ultrasat': 
-            command = f"gwemopt-run --telescopes {args.telescope} --geometry 3d --doTiles --doSchedule  --scheduleType greedy --doMovie --true_location  --true_ra {ra} --true_dec {dec} --true_distance {dist} --powerlaw_cl 0.9 --doObservability --timeallocationType powerlaw   --gpstime {gpstime} --event {skymap_file} --filters {args.filters} --exposuretimes {exposuretime} --doSingleExposure --doAlternatingFilters --doEfficiency --lightcurveFiles {lc_file}  -o {outdir} --modelType file --doPlots --doUsePrimary --ignore_observability"
+            command = f"gwemopt-run --telescopes {args.telescope} --geometry 3d --doTiles --doSchedule  --scheduleType greedy_slew --doTrueLocation --true_location  --true_ra {ra} --true_dec {dec} --true_distance {dist} --powerlaw_cl 0.9 --doObservability --doObservabilityExit --timeallocationType powerlaw   --gpstime {gpstime} --event {skymap_file} --filters {args.filters} --exposuretimes {exposuretime} --doSingleExposure --doAlternatingFilters --doEfficiency --lightcurveFiles {lc_file}  -o {outdir} --modelType file --doPlots --doUsePrimary  --ignore_observability"
             
         else:
-            command = f"gwemopt-run --telescopes {args.telescope} --geometry 3d --doTiles --doSchedule  --scheduleType greedy --doMovie --true_location  --true_ra {ra} --true_dec {dec} --true_distance {dist} --powerlaw_cl 0.9 --doObservability --timeallocationType powerlaw   --gpstime {gpstime} --event {skymap_file} --filters {args.filters} --exposuretimes {exposuretime} --doSingleExposure --doAlternatingFilters --doEfficiency --lightcurveFiles {lc_file}  -o {outdir} --modelType file --doPlots --doUsePrimary"
+            command = f"gwemopt-run --telescopes {args.telescope} --geometry 3d --doTiles --doSchedule  --scheduleType greedy_slew --doTrueLocation --true_location  --true_ra {ra} --true_dec {dec} --true_distance {dist} --powerlaw_cl 0.9 --doObservability --doObservabilityExit --timeallocationType powerlaw   --gpstime {gpstime} --event {skymap_file} --filters {args.filters} --exposuretimes {exposuretime} --doSingleExposure --doAlternatingFilters --doEfficiency --lightcurveFiles {lc_file}  -o {outdir} --modelType file --doPlots --doUsePrimary"
         
         commands.append(command)
         

--- a/nmma/eos/create_injection.py
+++ b/nmma/eos/create_injection.py
@@ -58,20 +58,23 @@ def file_to_dataframe(
         injection_values["mass_2"].append(min(float(row["mass1"]), float(row["mass2"])))
         injection_values["luminosity_distance"].append(float(row["distance"]))
 
-        if "polarization" in row:
+        if "polarization" in row.colnames:
             injection_values["psi"].append(float(row["polarization"]))
         else:
             injection_values["psi"].append(0.0)
 
-        if "coa_phase" in row:
+        if "coa_phase" in row.colnames:
             coa_phase = float(row["coa_phase"])
             injection_values["phase"].append(float(row["coa_phase"]))
         else:
             coa_phase = 0.0
             injection_values["phase"].append(0.0)
 
-        if "geocent_end_time" in row:
-            injection_values["geocent_time"].append(float(row["geocent_end_time"]))
+        if "geocent_end_time" in row.colnames:
+            if "geocent_end_time_ns" in row.colnames:
+                injection_values["geocent_time"].append(float(row["geocent_end_time"]) + float(row["geocent_end_time_ns"]) * (10 ** -9))
+            else:
+                injection_values["geocent_time"].append(float(row["geocent_end_time"]))
         else:
             injection_values["geocent_time"].append(trigger_time)
 


### PR DESCRIPTION
This pull request is designed to address and introduce certain processes:

1. **Bilby Integration with gpstime:**
   - The process now utilizes gpstime provided in the `injections.dat` file for enhanced accuracy.

2. **Integration of snscosmo _BANDPASS_INTERPOLATORS:**
   - Added functionality to retrieve bandpass interpolators, with support for the 'ultrasat' filter. This enhancement extends the capabilities of our bandpass interpolation.

3. **Revamp of EM Counterpart Detection in gwemopt:**
   - The detection process for Electromagnetic (EM) counterparts has been restructured. This update is focused on incorporating a range of telescopes including ULTRASAT, LSST, ZTF, and others specified in the gwemopt config file.
   - Default proxy filters are set as follows:
     - 'ultrasat' band for ULTRASAT   (noting that 'ultrasat' is the only filter  of ULTRASAT )
     - 'ps1__r' band for LSST.
     - 'ztfr' band for ZTF.
   - For telescopes other than ULTRASAT, LSST, and ZTF, users are required to specify the proxy band.
