### PR TITLE
Refactor resample_grid.py to enable script installation

### DIFF
--- a/doc/training.md
+++ b/doc/training.md
@@ -1,5 +1,5 @@
 
-## Training overview
+## Training
 
 It is common to have light curves on "grids", for which you have a discrete set of parameters for which the lightcurves were simulated. For example, we may know the lightcurves to expect for specific masses m_1 and m_2, but not for any masses between the two.
 
@@ -79,6 +79,10 @@ This model is then ready to use in an analysis.
 	lightcurve-analysis --model Bu2022mv --interpolation-type tensorflow --svd-path svdmodels --outdir outdir --label AT2017gfo --trigger-time 57982.5285236896 --data example_files/lightcurves/GW170817.dat --prior priors/Bu2022mv.prior
 
 To continue training an existing tensorflow model (e.g. on additional data), set the --continue-training flag.
+
+For the HDF5 file format, the `resample-grid` script enables downsampling and fragmentation into smaller components to make training less computationally demanding. For example:
+
+	resample-grid --gridpath nmma/tests/data/lowmass_collapsar_updated.h5 --factor 5 --do-downsample
 
 ### Spectral grids
 

--- a/nmma/tests/tools.py
+++ b/nmma/tests/tools.py
@@ -1,7 +1,7 @@
 import os
 from argparse import Namespace
 
-from tools.resample_grid import Grid
+from tools import resample_grid
 from tools import convert_skyportal_lcs
 
 
@@ -12,18 +12,31 @@ def test_resampling():
     base_filename = "lcs"
     gridpath = os.path.join(workingDir, "data", "lowmass_collapsar_updated.h5")
 
-    grid = Grid(
+    # Start with downsampling by 5x, no shuffle
+    args = Namespace(
         gridpath=gridpath,
         random_seed=21,
         base_dirname=base_dirname,
         base_filename=base_filename,
+        do_downsample=True,
+        do_fragment=False,
+        factor=5,
+        shuffle=False,
     )
+    resample_grid.main(args)
 
-    grid.downsample(factor=5, shuffle=False)
-    grid.downsample(factor=5, shuffle=True)
+    # Downsample by 5x, shuffle
+    args.shuffle = True
+    resample_grid.main(args)
 
-    grid.fragment(factor=5, shuffle=False)
-    grid.fragment(factor=5, shuffle=True)
+    # Fragment by 5x, shuffle
+    args.do_downsample = False
+    args.do_fragment = True
+    resample_grid.main(args)
+
+    # Fragment by 5x, no shuffle
+    args.shuffle = False
+    resample_grid.main(args)
 
 
 def test_lc_conversion():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,7 @@ gwem-resampling = "nmma.em.gwem_resampling:main"
 gwem-resampling-condor = "nmma.em.gwem_resampling_condor:main"
 gwem-Hubble-estimate = "nmma.em.gwem_Hubble_estimate:main"
 convert-skyportal-lcs = "tools.convert_skyportal_lcs:main"
+resample-grid = "tools.resample_grid:main"
 
 
 [tool.setuptools]

--- a/tools/resample_grid.py
+++ b/tools/resample_grid.py
@@ -96,7 +96,7 @@ class Grid:
                 new_file.copy(original_obj, key)
 
 
-if __name__ == "__main__":
+def get_parser():
     parser = argparse.ArgumentParser()
 
     parser.add_argument(
@@ -143,7 +143,13 @@ if __name__ == "__main__":
         help="Random seed for numpy",
     )
 
-    args = parser.parse_args()
+    return parser
+
+
+def main(args=None):
+    if args is None:
+        parser = get_parser()
+        args = parser.parse_args()
 
     if not args.gridpath.endswith(".h5"):
         raise ValueError(


### PR DESCRIPTION
This PR refactors `resample_grid.py` to allow `resample-grid` to be installed as a script in `pyproject.toml`. The PR also adds a unit test and updates training docs.