### PR TITLE
Only run docker CI/website deploy workflows on primary repo

### DIFF
--- a/.github/workflows/build-deploy-container.yml
+++ b/.github/workflows/build-deploy-container.yml
@@ -8,6 +8,7 @@ env:
 
 jobs:
   build:
+    if: github.repository_owner == 'nuclear-multimessenger-astronomy'
     runs-on: ubuntu-latest
 
     strategy:
@@ -64,37 +65,38 @@ jobs:
           retention-days: 1
 
   merge:
-      runs-on: ubuntu-latest
-      needs:
-        - build
-      steps:
-        - name: Download digests
-          uses: actions/download-artifact@v3
-          with:
-            name: digests
-            path: /tmp/digests
+    if: github.repository_owner == 'nuclear-multimessenger-astronomy'
+    runs-on: ubuntu-latest
+    needs:
+      - build
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v3
+        with:
+          name: digests
+          path: /tmp/digests
 
-        - name: Docker meta
-          id: meta
-          uses: docker/metadata-action@v4
-          with:
-            images: ${{ env.REGISTRY_IMAGE }}
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ env.REGISTRY_IMAGE }}
 
-        - name: Set up Docker Buildx
-          uses: docker/setup-buildx-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
 
-        - name: Login to Docker Hub
-          uses: docker/login-action@v2
-          with:
-            username: ${{ secrets.DOCKER_HUB_USERNAME }}
-            password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
-        - name: Create manifest list and push
-          working-directory: /tmp/digests
-          run: |
-            docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-              $(printf '${{ env.REGISTRY_IMAGE }}@sha256:%s ' *)
-        -
-          name: Inspect image
-          run: |
-            docker buildx imagetools inspect ${{ env.REGISTRY_IMAGE }}:${{ steps.meta.outputs.version }}
+      - name: Create manifest list and push
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.REGISTRY_IMAGE }}@sha256:%s ' *)
+      -
+        name: Inspect image
+        run: |
+          docker buildx imagetools inspect ${{ env.REGISTRY_IMAGE }}:${{ steps.meta.outputs.version }}

--- a/.github/workflows/deploy-github-pages.yml
+++ b/.github/workflows/deploy-github-pages.yml
@@ -6,7 +6,6 @@ on:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -45,7 +44,7 @@ jobs:
         touch doc/_build/html/.nojekyll
 
     - name: Deploy to GitHub Pages
-      if: success()
+      if: success() && github.repository_owner == 'nuclear-multimessenger-astronomy'
       uses: crazy-max/ghaction-github-pages@v2
       with:
         target_branch: gh-pages


### PR DESCRIPTION
This PR adds the condition `if: github.repository_owner == 'nuclear-multimessenger-astronomy'` to the docker CI and website deploy workflows to prevent these from fully running unless the repository owner is `nuclear-multimessenger-astronomy`. This will prevent test failures when pushing the latest changes to forked repos. Note that most of the `build` job for GitHub pages will still run on forked repos, since only the final `Deploy to GitHub Pages` step fails.

Additionally, an extraneous level of indentation has been removed in `build-deploy-container.yml`.