### PR TITLE
Restrict to Python < 3.12

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ authors = [
 ]
 description = "A nuclear physics multi-messenger Bayesian inference library"
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.9, <3.12"
 license = {text = "GPLv3"}
 classifiers = [
     "Programming Language :: Python :: 3",


### PR DESCRIPTION
From Slack:

> sounds good to me. anyways we can't move to 3.12 until Tensorflow is available for 3.12
> but, will it help? because `scikit` error will appear before the python version error