### PR TITLE
Adding functionality for using Bayestar fit input for inclination

### DIFF
--- a/nmma/em/analysis.py
+++ b/nmma/em/analysis.py
@@ -378,12 +378,12 @@ def get_parser(**kwargs):
     )
 
     parser.add_argument(
-        "--fit-file",
-        help="Fit files output from Bayestar, to be used for constructing dL-iota prior"
+        "--fits-file",
+        help="Fits file output from Bayestar, to be used for constructing dL-iota prior"
     )
     parser.add_argument(
         "--cosiota-node-num",
-        help="Number of cos-iota nodes used in the Bayestar fit (default: 10)",
+        help="Number of cos-iota nodes used in the Bayestar fits (default: 10)",
         default=10,
     )
 

--- a/nmma/em/analysis.py
+++ b/nmma/em/analysis.py
@@ -378,6 +378,16 @@ def get_parser(**kwargs):
     )
 
     parser.add_argument(
+        "--fit-file",
+        help="Fit files output from Bayestar, to be used for constructing dL-iota prior"
+    )
+    parser.add_argument(
+        "--cosiota-node-num",
+        help="Number of cos-iota nodes used in the Bayestar fit (default: 10)",
+        default=10,
+    )
+
+    parser.add_argument(
         "--skip-sampling",
         help="If analysis has already run, skip bilby sampling and compute results from checkpoint files. Combine with --plot to make plots from these files.",
         action="store_true",

--- a/nmma/em/prior.py
+++ b/nmma/em/prior.py
@@ -72,10 +72,10 @@ def inclination_prior_from_fit(priors, args):
 
     # check if the sky location is input
     # if not, the maximum posterior point is taken
-    if args.ra and args.dec:
-        print(f"Using the input sky location ra={args.ra}, dec={args.dec}")
-        ra = args.ra
-        dec = args.dec
+    if 'ra' in priors and 'dec' in priors:
+        ra = priors['ra'].peak
+        dec = priors['dec'].peak
+        print(f"Using the input sky location ra={ra}, dec={dec}")
         # convert them back to theta and phi
         phi = np.deg2rad(ra)
         theta = 0.5 * np.pi - np.deg2rad(dec)

--- a/nmma/em/prior.py
+++ b/nmma/em/prior.py
@@ -120,7 +120,7 @@ def inclination_prior_from_fit(priors, args):
     # in GW, iota in [0, pi], but in EM, iota in [0, pi/2]
     # therefore, we need to do a folding
     # split the domain in half
-    iota_lt_pi2, iota_gt_pi2 = iota[iota < np.pi / 2], iota[iota >= np.pi / 2]
+    iota_lt_pi2 = iota[iota < np.pi / 2]
     prob_lt_pi2, prob_gt_pi2 = prob_iota[iota < np.pi / 2], prob_iota[iota >= np.pi / 2]
     iota_EM = iota_lt_pi2
     prob_iota_EM = prob_lt_pi2 + prob_gt_pi2[::-1]
@@ -131,8 +131,8 @@ def inclination_prior_from_fit(priors, args):
     priors['inclination_EM'] = Interped(
         xx=iota_EM,
         yy=prob_iota_EM,
-        minimum = 0,
-        maximum = np.pi / 2)
+        minimum=0,
+        maximum=np.pi / 2)
 
     if args.plot:
         figIdx = np.random.randint(1000)
@@ -143,6 +143,7 @@ def inclination_prior_from_fit(priors, args):
         plt.savefig(f"{args.outdir}/Fit_motivated_inclination_prior.png")
 
     return priors
+
 
 def create_prior_from_args(model_names, args):
 

--- a/nmma/em/prior.py
+++ b/nmma/em/prior.py
@@ -59,7 +59,7 @@ class ConditionalGaussianIotaGivenThetaCore(ConditionalTruncatedGaussian):
         return instantiation_dict
 
 
-def inclination_prior_from_fit(priors, args):
+def inclination_prior_from_fits(priors, args):
     from ligo.skymap import io, moc
     from scipy.interpolate import PchipInterpolator
     from scipy.stats import norm
@@ -72,7 +72,7 @@ def inclination_prior_from_fit(priors, args):
     print("Constructing prior on inclination with fits input")
 
     # load the skymap
-    skymap = io.read_sky_map(args.fit_file, moc=True)
+    skymap = io.read_sky_map(args.fits_file, moc=True)
 
     # check if the sky location is input
     # if not, the maximum posterior point is taken
@@ -140,7 +140,7 @@ def inclination_prior_from_fit(priors, args):
         plt.xlabel('Inclination')
         plt.ylabel('PDF')
         plt.plot(iota_EM, prob_iota_EM)
-        plt.savefig(f"{args.outdir}/Fit_motivated_inclination_prior.png")
+        plt.savefig(f"{args.outdir}/Fits_motivated_inclination_prior.png")
 
     return priors
 
@@ -206,7 +206,7 @@ def create_prior_from_args(model_names, args):
         priors_dict["inclination_EM"] = ConditionalGaussianIotaGivenThetaCore(**setup)
         priors = bilby.gw.prior.ConditionalPriorDict(priors_dict)
 
-    if args.fit_file:
-        priors = inclination_prior_from_fit(priors, args)
+    if args.fits_file:
+        priors = inclination_prior_from_fits(priors, args)
 
     return priors

--- a/nmma/em/prior.py
+++ b/nmma/em/prior.py
@@ -1,6 +1,7 @@
 import bilby
 import bilby.core
 from bilby.core.prior import Prior
+from bilby.core.prior.interpolated import Interped
 from bilby.core.prior.conditional import ConditionalTruncatedGaussian
 
 
@@ -57,6 +58,74 @@ class ConditionalGaussianIotaGivenThetaCore(ConditionalTruncatedGaussian):
                 instantiation_dict[key] = value
         return instantiation_dict
 
+
+def inclination_prior_from_fit(priors, args):
+    from ligo.skymap import io, moc
+    from scipy.interpolate import interp1d
+    from scipy.stats import norm
+    import healpy as hp
+
+    print("Constructing prior on inclination with fits input")
+
+    # load the skymap
+    skymap = io.read_sky_map(args.fits_file, moc=True)
+
+    # check if the sky location is input
+    # if not, the maximum posterior point is taken
+    if args.ra and args.dec:
+        print(f"Using the input sky location ra={args.ra}, dec={args.dec}")
+        ra = args.ra
+        dec = args.dec
+        # convert them back to theta and phi
+        phi = np.deg2rad(ra)
+        theta = 0.5 * np.pi - np.deg2rad(dec)
+        # get the nested_idx
+    else:
+        print("Using the maP point from the fits file input")
+        maP_idx = np.argmax(skymap['PROBDENSITY'])
+        uniq_idx = skymap[maP_idx]['UNIQ']
+        # convert to nested indexing and find the location of that index
+        order, nest_idx = moc.uniq2nest(uniq_idx)
+        nside = hp.order2nside(order)
+        theta, phi = hp.pix2ang(nside, int(nest_idx), nest=True)
+        # convert theta and phi to ra and dec
+        ra = np.rad2deg(phi)
+        dec = np.rad2deg(0.5 * np.pi - theta)
+        print(f"The maP location is ra={ra}, dec={dec}")
+        # fetching the skymap row
+        row = skymap[maP_idx]
+
+    # construct the iota prior
+    cosiota_nodes_num = args.cosiota_node_num
+    cosiota_nodes = np.cos(np.linspace(0, np.pi, cosiota_nodes_num))
+    colnames = ['PROBDENSITY', 'DISTMU', 'DISTSIGMA', 'DISTNORM']
+    # do an all-in-one interpolation
+    prob_density, dist_mu, dist_sigma, dist_norm = (
+        interp1d(
+            cosiota_nodes, row['{}_SAMPLES'.format(colname)], kind='cubic'
+        )
+        for colname in colnames)
+    # now have the joint distribution evaluated
+    u = np.linspace(-1, 1, 1000)  # this is cosiota
+    # fetch the fixed distance
+    dL = priors['luminosity_distance'].peak
+    prob_u = prob_density(u) * dist_norm * np.square(dL) * norm(dist_mu(u), dist_sigma(u)).pdf(u)
+    iota = np.arccos(u)
+    prob_iota = prob_u * np.sin(iota)
+    # in GW, iota in [0, pi], but in EM, iota in [0, pi/2]
+    # therefore, we need to do a folding
+    # split the domain in half
+    iota_lt_pi2, iota_gt_pi2 = iota[iota < np.pi / 2], iota[iota >= np.pi / 2]
+    prob_lt_pi2, prob_gt_pi2 = prob_iota[iota < np.pi / 2], prob_iota[iota >= np.pi / 2]
+    iota_EM = iota_lt_pi2
+    prob_iota_EM = prob_lt_pi2 + prob_gt_pi2[::-1]
+
+    # normalize
+    prob_iota /= np.trapz(iota_EM, prob_iota_EM)
+
+    priors['inclination_EM'] = Interped(xx=iota_EM, yy=prob_iota_EM)
+
+    return priors
 
 def create_prior_from_args(model_names, args):
 
@@ -118,5 +187,8 @@ def create_prior_from_args(model_names, args):
 
         priors_dict["inclination_EM"] = ConditionalGaussianIotaGivenThetaCore(**setup)
         priors = bilby.gw.prior.ConditionalPriorDict(priors_dict)
+
+    if args.fits_file:
+        priors = inclination_prior_from_fit(priors, args):
 
     return priors

--- a/nmma/tests/analysis.py
+++ b/nmma/tests/analysis.py
@@ -72,6 +72,8 @@ def args():
         verbose=False,
         local_only=True,
         skip_sampling=False,
+        fits_file=None,
+        cosiota_node_num=10
     )
 
     return args

--- a/nmma/tests/analysis_lbol.py
+++ b/nmma/tests/analysis_lbol.py
@@ -40,6 +40,8 @@ def args():
         sampler_kwargs="{}",
         verbose=False,
         skip_sampling=False,
+        fits_file=None,
+        cosiota_node_num=10
     )
 
     return args

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,5 @@ ultranest
 tornado
 tensorflow
 notebook
+ligo.skymap
+healpy


### PR DESCRIPTION
The PR allows for the Bayestar output fits to be used as inclination prior for NMMA;

A small test case is showing an expected behaviour

Corner plot without the fit input
![image](https://github.com/nuclear-multimessenger-astronomy/nmma/assets/23866970/3b17d8e4-bf82-40ad-9d41-deb78c09060a)

Corner plot with the fit input
![image](https://github.com/nuclear-multimessenger-astronomy/nmma/assets/23866970/0d34f106-6036-4644-bbab-92e63edecda9)

The fit input;
![image](https://github.com/nuclear-multimessenger-astronomy/nmma/assets/23866970/88c7301c-05b5-4d53-8fe8-41c43a8c3bbe)

Currently, only a fixed distance prior is supported and, by default, takes the maP sky location. Subsequent PRs will expand the functionality.