### PR TITLE
Restrict tensorflow to <=2.15.0 to avoid new errors

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ arviz
 p_tqdm
 ultranest
 tornado
-tensorflow
+tensorflow<=2.15.0
 notebook
 ligo.skymap
 healpy


### PR DESCRIPTION
This PR restricts the tensorflow version to <=2.15.0 to avoid new errors during unit tests, e.g. 
```TypeError: Could not locate function 'mse'. Make sure custom classes are decorated with `@keras.saving.register_keras_serializable()`. Full object config: {'module': 'keras.metrics', 'class_name': 'function', 'config': 'mse', 'registered_name': 'mse'}```