### PR TITLE
Modify analysis slurm script to include PRIOR variable

### DIFF
--- a/tools/analysis_slurm.py
+++ b/tools/analysis_slurm.py
@@ -120,7 +120,7 @@ def main(args=None):
         "label": "$LABEL",
         "trigger_time": "$TT",
         "data": "$DATA",
-        "prior": "priors/$MODEL.prior",
+        "prior": "priors/$PRIOR.prior",
         "tmin": "$TMIN",
         "tmax": "$TMAX",
         "dt": "$DT",


### PR DESCRIPTION
This PR adds a `PRIOR` variable used by the API service in generated analysis slurm scripts (see also https://github.com/Theodlz/nmma-api/pull/14).