### PR TITLE
Update docker/build-push-action from v4 to v5

### DIFF
--- a/.github/workflows/build-deploy-container.yml
+++ b/.github/workflows/build-deploy-container.yml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Build and push
         id: build
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v5
         with:
           context: .
           file: ./api/Dockerfile


### PR DESCRIPTION
Our "build and push" CI current fails for the arm64 architecture. This PR updates the version of `build-push-action` from v4 to v5 in an attempt to fix this.