### PR TITLE
More consistent loading of lightcurve files

### DIFF
--- a/nmma/em/analysis.py
+++ b/nmma/em/analysis.py
@@ -565,15 +565,8 @@ def analysis(args):
             lc.to_csv(args.injection_outfile)
 
     else:
-        # load the kilonova afterglow data
-        try:
-            data = loadEvent(args.data)
-
-        except ValueError:
-            with open(args.data) as f:
-                data = json.load(f)
-                for key in data.keys():
-                    data[key] = np.array(data[key])
+        # load the lightcurve data
+        data = loadEvent(args.data)
 
         if args.trigger_time is None:
             # load the minimum time as trigger time

--- a/nmma/em/io.py
+++ b/nmma/em/io.py
@@ -10,7 +10,12 @@ from sncosmo.bandpasses import _BANDPASSES
 
 
 def loadEvent(filename):
-    try:
+    if filename.endswith(".json"):
+        with open(filename) as f:
+            data = json.load(f)
+            for key in data.keys():
+                data[key] = np.array(data[key])
+    else:
         lines = [line.rstrip("\n") for line in open(filename)]
         lines = filter(None, lines)
 
@@ -33,12 +38,6 @@ def loadEvent(filename):
             if filt not in data:
                 data[filt] = np.empty((0, 3), float)
             data[filt] = np.append(data[filt], np.array([[mjd, mag, dmag]]), axis=0)
-    ## attempts to load the file with json in the event that the standard method fails
-    except ValueError:
-        with open(filename) as f:
-            data = json.load(f)
-            for key in data.keys():
-                data[key] = np.array(data[key])
 
     return data
 

--- a/nmma/em/io.py
+++ b/nmma/em/io.py
@@ -10,6 +10,15 @@ from sncosmo.bandpasses import _BANDPASSES
 
 
 def loadEvent(filename):
+    """
+    Reads in lightcurve data from a file and returns data in a dictionary format.
+    
+    Args:
+    - filename (str): Path to lightcurve file
+    
+    Returns:
+    - data (dict): Dictionary containing the lightcurve data from the file. The keys are generally 't' and each of the filters in the file as well as their accompanying error values.
+    """
     if filename.endswith(".json"):
         with open(filename) as f:
             data = json.load(f)


### PR DESCRIPTION
Moves the try except for loading lightcurve files into the loadEvent function in io.py. This is so calls to loadEvent will work even if the supplied file is a json file. Originally, this was precent in analysis.py, but there are other calls to loadEvent, and we should preserve file compatibility for lightcurve file loading between different functions in nmma.