### PR TITLE
Restructure sncosmo.get_bandpass block in get_default_filts_lambdas

### DIFF
--- a/nmma/em/utils.py
+++ b/nmma/em/utils.py
@@ -324,12 +324,19 @@ def get_default_filts_lambdas(filters=None):
 
     bandpasses = []
     for val in get_all_bandpass_metadata():
-        try:
+        if val["name"] in [
+            "ultrasat",
+            "megacampsf::u",
+            "megacampsf::g",
+            "megacampsf::r",
+            "megacampsf::i",
+            "megacampsf::z",
+            "megacampsf::y",
+        ]:
+            bandpass = sncosmo.get_bandpass(val["name"], 3)
+            bandpass.name = bandpass.name.split()[0]
+        else:
             bandpass = sncosmo.get_bandpass(val["name"])
-        except Exception:
-            if val["name"] == "ultrasat":
-                bandpass = sncosmo.get_bandpass(val["name"], 3)
-                bandpass.name = bandpass.name.split()[0]
 
         bandpasses.append(bandpass)
 


### PR DESCRIPTION
Motivated by issues running on a cluster that cannot make external internet connections, this PR restructures a block that gets sncosmo filter bandpasses in `get_default_filts_lambdas`. The removed try/except masked informative errors raised on this cluster installation, so it is instead replaced by an if/else specifying the filters that must be loaded as `AggregateBandpass` rather than `Bandpass` objects. `megacampsf` filters are added to the list that previously included only `ultrasat`.