### PR TITLE
Update of resampling methods

### DIFF
--- a/nmma/joint/maximum_mass_constraint.py
+++ b/nmma/joint/maximum_mass_constraint.py
@@ -1,0 +1,118 @@
+from . import maximum_mass_constraint_utils as utils
+import pandas as pd
+import numpy as np
+import bilby
+import argparse
+import os
+
+
+def main():
+
+    parser = argparse.ArgumentParser(
+        description="Inference on the maximum mass constraint of the EOS when a joint posterior for binary components, ejecta and EOS is provided."
+    )
+    parser.add_argument(
+            "--outdir", 
+            metavar="PATH", 
+            type=str, 
+            required=True
+    )
+    parser.add_argument(
+            "--joint-posterior", 
+            metavar="PATH", 
+            type=str, 
+            required=True,
+            help="Posterior file with chirp mass, eta_star, EOSID, log10_mdisk, log10_mej_dyn as columns."
+    )
+    parser.add_argument(
+            "--prior",
+            metavar="PATH",
+            type=str,
+            required=True,
+            help="Prior specification for chirp mass, eta_star, log10_mdisk, log10_mej_dyn. If use_M_kepler is True, prior file must also contain ratio_R and delta.",
+    )
+    parser.add_argument(
+            "--eos-path-macro", 
+            metavar="PATH", 
+            type=str, 
+            required=True,
+            help="EOS folder with EOS files in [R, M, Lambda, p_central] format."
+    )
+    parser.add_argument(
+            "--eos-path-micro", 
+            metavar="PATH", 
+            type=str, 
+            required=True,
+            help="EOS folder with EOS files in [n, energy density, pressure, speed of sound squared] format."
+    )
+    parser.add_argument(
+            "--use_M_Kepler", 
+            action="store_true",
+            help="If set, it is assumed that the BNS remnant collapsed to a black hole above the Kepler limit.",
+
+    )
+    parser.add_argument(
+            "--nlive", 
+            metavar="nlive", 
+            type=int, 
+            required=False, 
+            default=1024
+    )
+
+    args = vars(parser.parse_args())
+    try:
+       os.makedirs(args["outdir"] + "/pm/")
+    except:
+       pass
+    
+    posterior_samples = pd.read_csv(args["joint_posterior"], header = 0, delimiter = " ")
+    prior = bilby.gw.prior.PriorDict(args["prior"])
+    Neos = len(next(os.walk(args["eos_path_macro"]))[2])
+    
+   
+    if args["use_M_Kepler"]:
+       n_dims = 7
+       if len(prior.keys())!= n_dims-1:
+          raise Exception("If use_M_kepler is True, you need to provide a prior fo ratio_R and delta to be used in the quasi-universal relation.")
+
+    else:
+       n_dims = 5
+    
+    
+    
+    
+    pymulti_kwargs = dict(
+                outputfiles_basename=args["outdir"] + "/pm/",
+                n_dims=n_dims,
+                n_live_points=args["nlive"],
+                verbose=True,
+                resume=True,
+                seed=42,
+                importance_nested_sampling=False,
+                use_MPI = True,
+            )
+    
+    solution = utils.PostmergerInference(prior, posterior_samples, Neos, args["eos_path_macro"], args["eos_path_micro"], args["use_M_Kepler"], **pymulti_kwargs)
+    
+    
+    samples = solution.samples.T
+    posterior = dict()
+    
+    posterior["chirp_mass"] = samples[0]
+    posterior["eta_star"] = samples[1]
+    posterior["EOS"] = samples[2]
+    posterior["log10_mdisk"] = samples[3]
+    posterior["log10_mej_dyn"] = samples[4]
+    
+    if args["use_M_Kepler"]:
+       posterior["ratio_R"] = samples[5]
+       posterior["delta"] = samples[6]
+    
+    
+    posterior = pd.DataFrame.from_dict(posterior)
+    posterior.to_csv(args["outdir"]+"/posterior_samples.dat", sep = " ", index = False)
+        
+        
+
+if __name__ == "__main__":
+    main()

--- a/nmma/joint/maximum_mass_constraint_utils.py
+++ b/nmma/joint/maximum_mass_constraint_utils.py
@@ -1,0 +1,186 @@
+import numpy as np
+import scipy.stats
+import scipy.interpolate
+import scipy.integrate
+
+from bilby.gw.prior import PriorDict
+from bilby.core.prior import Uniform
+import bilby.gw.conversion as conversion
+
+import os
+import sys
+import contextlib
+
+def fileno(file_or_fd):
+    fd = getattr(file_or_fd, 'fileno', lambda: file_or_fd)()
+    if not isinstance(fd, int):
+        raise ValueError("Expected a file (`.fileno()`) or a file descriptor")
+    return fd
+
+@contextlib.contextmanager
+def stdout_redirected(to=os.devnull, stdout=None):
+    """
+    https://stackoverflow.com/a/22434262/190597 (J.F. Sebastian)
+    """
+    if stdout is None:
+       stdout = sys.stdout
+
+    stdout_fd = fileno(stdout)
+    # copy stdout_fd before it is overwritten
+    #NOTE: `copied` is inheritable on Windows when duplicating a standard stream
+    with os.fdopen(os.dup(stdout_fd), 'wb') as copied: 
+        stdout.flush()  # flush library buffers that dup2 knows nothing about
+        try:
+            os.dup2(fileno(to), stdout_fd)  # $ exec >&to
+        except ValueError:  # filename
+            with open(to, 'wb') as to_file:
+                os.dup2(to_file.fileno(), stdout_fd)  # $ exec > to
+        try:
+            yield stdout # allow code to be run with the redirected stdout
+        finally:
+            # restore stdout to its previous value
+            #NOTE: dup2 makes stdout_fd inheritable unconditionally
+            stdout.flush()
+            os.dup2(copied.fileno(), stdout_fd)  # $ exec >&copied
+
+
+
+def baryonic_mass(gravitational_mass, EOS, eos_path_macro, eos_path_micro):
+
+    Msun_to_MeV = 1.11549833*10**60
+    G = 1.4766696910334391 #G/c^2 in km/Msun
+    R, M, L, P0 = np.loadtxt(eos_path_macro+f"/{EOS}.dat", unpack= True, skiprows = 0)
+    N, EPS, P, CS2 = np.loadtxt(eos_path_micro+f"/{EOS}.dat", unpack = True, skiprows = 0)
+    eps_of_p = scipy.interpolate.interp1d(P, EPS, kind = 'linear', bounds_error = False, fill_value =0)
+
+
+    def TOVeq(y, x):
+      p, m = y
+      eps = eps_of_p(p)
+
+      Dp = -G*m*eps/x**2 * (1+p/eps) * (1+4*np.pi*(x**3* p)*8.964603290800086e-07/m) * (1-2*G*m/x)**(-1)
+      Dm = (4*np.pi*x**2*eps)*8.964603290800086e-07 #1 MeV/fm^3 km^2 are 8.965123536*10**(-7) Msun/km
+
+      return [Dp, Dm]
+
+    dr =0.001
+    r = np.interp(gravitational_mass, M, R)
+    p0= np.interp(gravitational_mass, M, P0)
+    eps0 = eps_of_p(p0)
+    m0 = (eps0*4*np.pi/3*dr**3)*8.964603290800086e-07 #convert Mev/fm^3 * km^3 in Msun
+    x = np.arange(dr, r+dr, dr)
+    y0 = [p0, m0]
+
+    with stdout_redirected():
+         p_solv, m_solv = scipy.integrate.odeint(TOVeq, y0=y0, t = x).T
+    n_solv = np.interp(p_solv, P, N)
+
+
+    if np.any(np.isnan(p_solv)):
+       cut = np.where(np.isnan(p_solv))[0][0]
+       if np.any(np.isnan(m_solv)):
+          cut = min(cut, np.where(np.isnan(m_solv))[0][0])
+       n_solv = n_solv[:cut]; m_solv = m_solv[:cut]; x= x[:cut]
+
+
+    particle_mass = 8.40893833 * 10**(-4) #proton mass in Msun*(fm/km)**3
+    m_baryonic = particle_mass*4*np.pi*scipy.integrate.simpson((n_solv)*x**2/np.sqrt(1-2*G*m_solv/x), x)
+    
+    if np.isnan(m_baryonic):
+       import warnings
+       warnings.warn("baryonic_mass returned nan")
+
+    return m_baryonic
+
+
+def baryonic_Kepler_mass(mTOV, R_14, ratio_R, delta):
+   """
+   see https://arxiv.org/abs/2307.03225 and https://arxiv.org/abs/1905.03784
+   """
+   m_max = ratio_R*mTOV
+   m_max_b = m_max + 0.78/R_14 * m_max**2
+   m_max_b *= (1+delta)
+
+   return m_max_b
+
+
+from pymultinest.solve import Solver
+
+class PostmergerInference(Solver):
+    """
+    Class to sample over a joint GW+EM posterior and to determine the remnant mass of the system.
+    It is assumed that the remnant collapsed to a black hole and thus the TOV mass of the EOS must be smaller than this number.
+    See https://arxiv.org/abs/2402.04172 for details.
+    """
+
+    def __init__(self, prior, posterior_samples, Neos, eos_path_macro, eos_path_micro, use_M_max = False, **kwargs):
+        self.posterior_samples = posterior_samples
+        self.use_M_max = use_M_max
+
+
+        self.priors = {'chirp_mass': prior['chirp_mass'],
+                       'eta_star': prior['eta_star'],
+                       'EOS': Uniform(name = "EOS", minimum=0, maximum=Neos),
+                       'log10_mdisk': prior['log10_mdisk'],
+                       'log10_mej_dyn': prior['log10_mej_dyn']
+                       }
+        if self.use_M_max:
+            self.priors["ratio_R"] = prior["ratio_R"]
+            self.priors["delta"] = prior["delta"]
+
+
+        self.priors = PriorDict(self.priors)
+        self._search_parameter_keys = self.priors.keys()
+        self.Neos = Neos
+        self.eos_path_macro = eos_path_macro
+        self.eos_path_micro = eos_path_micro
+
+        chirp_mass = self.posterior_samples.chirp_mass.to_numpy()
+        eta_star = self.posterior_samples.eta_star.to_numpy()
+        EOS = self.posterior_samples.EOS.to_numpy()
+        log10_mej_dyn = self.posterior_samples.log10_mej_dyn.to_numpy()
+        log10_mdisk = self.posterior_samples.log10_mdisk.to_numpy()
+
+        self.KDE = scipy.stats.gaussian_kde((chirp_mass, eta_star, EOS, log10_mdisk, log10_mej_dyn))
+
+        Solver.__init__(self, **kwargs)
+
+    def Prior(self, x):
+        return self.priors.rescale(self._search_parameter_keys, x)
+
+    def LogLikelihood(self, x):
+
+        if self.use_M_max:
+           chirp_mass, eta_star, EOS, log10_mdisk, log10_mej_dyn, ratio_R, delta = x
+
+        else:
+           chirp_mass, eta_star, EOS, log10_mdisk, log10_mej_dyn = x
+
+
+        logprior = self.KDE.logpdf((chirp_mass, eta_star, EOS, log10_mdisk, log10_mej_dyn)) #use the joint GW+EM posterior as "prior" here
+
+        EOS = int(EOS) + 1
+        R, M = np.loadtxt(self.eos_path_macro+f"/{EOS}.dat", unpack = True, usecols = [0,1], skiprows = 0)
+        mTOV = M.max()
+        R_14 = np.interp(1.4, M, R)
+
+        q = conversion.symmetric_mass_ratio_to_mass_ratio(0.25-np.exp(eta_star))
+        mass_1, mass_2 = conversion.chirp_mass_and_mass_ratio_to_component_masses(chirp_mass, q)
+        mdisk = 10**log10_mdisk
+        mej_dyn = 10**log10_mej_dyn
+
+        m_rem_b = baryonic_mass(mass_1, EOS, self.eos_path_macro, self.eos_path_micro) + baryonic_mass(mass_2, EOS, self.eos_path_macro, self.eos_path_micro) - mdisk - mej_dyn #calculate the baryonic remnant mass
+
+        if self.use_M_max:
+           m_threshold = baryonic_Kepler_mass(mTOV, R_14, ratio_R, delta) #if the Kepler limit is the threshold, use the quasiuniversal relation
+
+        else:
+           m_threshold = baryonic_mass(mTOV, EOS, self.eos_path_macro, self.eos_path_micro) #if the TOV mass is the limit just determine its baryonic mass
+
+
+        if m_threshold > m_rem_b:
+           loglikelihood = np.nan_to_num(-np.inf)
+        else:
+           loglikelihood = 0
+
+        return logprior + loglikelihood

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,7 @@ nmma-create-injection = "nmma.eos.create_injection:main"
 gwem-resampling = "nmma.em.gwem_resampling:main"
 gwem-resampling-condor = "nmma.em.gwem_resampling_condor:main"
 gwem-Hubble-estimate = "nmma.em.gwem_Hubble_estimate:main"
+maximum-mass-constraint = "nmma.joint.maximum_mass_constraint:main"
 convert-skyportal-lcs = "tools.convert_skyportal_lcs:main"
 resample-grid = "tools.resample_grid:main"
 


### PR DESCRIPTION
Changed the definition of the prior in gwem-resampling to account for correlation between chirp mass and mass ratio (and potentially spin in NSBH systems).

Added maximum-mass-constraint as a command, so one can sample from a joint GW+EM posterior and get an upper limit on the TOV mass.