### PR TITLE
Remove LANL2022 model in favor of specific morphologies

### DIFF
--- a/doc/models.md
+++ b/doc/models.md
@@ -55,7 +55,7 @@ The original light curves are available on GitHub [here](https://github.com/mbul
 
 #### Wollaeger et al. 2021
 
-We use a model from [Wollaeger et al. 2021](https://arxiv.org/abs/2105.11543) spanning the plausible binary neutron star parameter space. The model is named LANL2022 in the code, and there are a number of geometries to choose from (see [here](https://github.com/nuclear-multimessenger-astronomy/nmma/blob/main/nmma/em/model.py#L59) for LANL list). The model parameters are:
+We use a model from [Wollaeger et al. 2021](https://arxiv.org/abs/2105.11543) spanning the plausible binary neutron star parameter space. The models are named LANLTS1, LANLTS2, LANLTP1, and LANLTP2 in the code, representing the different geometries to choose from (see [here](https://github.com/nuclear-multimessenger-astronomy/nmma/blob/main/nmma/em/model.py#L72) for LANL list). The model parameters are:
 
 * dynamical ejecta mass $M^{\rm dyn}_{\rm ej}$
 * dynamical ejecta velocity $v^{\rm dyn}_{\rm ej}$

--- a/nmma/em/model.py
+++ b/nmma/em/model.py
@@ -69,13 +69,6 @@ model_parameters_dict = {
         "Yewind",
         "KNtheta",
     ],
-    "LANL2022": [
-        "log10_mej_dyn",
-        "vej_dyn",
-        "log10_mej_wind",
-        "vej_wind",
-        "KNtheta",
-    ],
     "LANLTP1": [
         "log10_mej_dyn",
         "vej_dyn",
@@ -372,7 +365,7 @@ class SVDLightCurveModel(object):
         nu_0s = scipy.constants.c / lambdas
 
         try:
-            Ebv = new_parameters['Ebv']
+            Ebv = new_parameters["Ebv"]
             if Ebv != 0.0:
                 ext = utils.extinctionFactorP92SMC(nu_0s, Ebv, z)
                 ext_mag = -2.5 * np.log10(ext)

--- a/nmma/em/model_parameters.py
+++ b/nmma/em/model_parameters.py
@@ -1,10 +1,9 @@
-
-
 """Script with various functions to extract the parameters of models from their naming convention for filenames."""
 import re
 import numpy as np
 
 from .utils import get_knprops_from_LANLfilename
+
 
 def AnBa2022_linear(data):
 
@@ -210,6 +209,7 @@ def Bu2022Ye(data):
 
     return data_out, parameters
 
+
 def Bu2023Ye(data):
 
     data_out = {}
@@ -278,36 +278,6 @@ def Ka2017(data):
     return data_out, parameters
 
 
-def LANL2022(data):
-
-    parameters = [
-        # "Ye_wind",
-        "log10_mej_dyn",
-        "vej_dyn",
-        "log10_mej_wind",
-        "vej_wind",
-        "KNtheta",
-    ]
-
-    data_out = {}
-
-    magkeys = data.keys()
-    for jj, key in enumerate(magkeys):
-        knprops = get_knprops_from_LANLfilename(key)
-
-        # best to interpolate masses in log10
-        knprops["log10_mej_dyn"] = np.log10(knprops["mej_dyn"])
-        knprops["log10_mej_wind"] = np.log10(knprops["mej_wind"])
-        del knprops["mej_dyn"]
-        del knprops["mej_wind"]
-        # del knprops["morphology"]
-
-        data_out[key] = knprops
-        data_out[key] = {**data_out[key], **data[key]}
-
-    return data_out, parameters
-
-
 def LANLTP1(data):
 
     parameters = [
@@ -366,6 +336,7 @@ def LANLTS1(data):
         data_out[key] = {**data_out[key], **data[key]}
 
     return data_out, parameters
+
 
 def LANLTP2(data):
 

--- a/tools/tf_training_calls.sh
+++ b/tools/tf_training_calls.sh
@@ -1,8 +1,20 @@
 # Example tensorflow training calls for different model grids
 
+# model: LANLTS1
+# lightcurves: lcs_lanl_TS_wind1
+create-svdmodel --model LANLTS1 --svd-path svdmodels_LANLTS1 --interpolation-type tensorflow --tmin 0. --tmax 21.0 --dt 0.1 --data-path lcs_lanl_TS_wind1 --tensorflow-nepochs 100 --outdir output_LANLTS1_tf --plot
+
 # model: LANLTS2
 # lightcurves: lcs_lanl_TS_wind2
 create-svdmodel --model LANLTS2 --svd-path svdmodels_LANLTS2 --interpolation-type tensorflow --tmin 0. --tmax 21.0 --dt 0.1 --data-path lcs_lanl_TS_wind2 --tensorflow-nepochs 100 --outdir output_LANLTS2_tf --plot
+
+# model: LANLTP1
+# lightcurves: lcs_lanl_TP_wind1
+create-svdmodel --model LANLTP1 --svd-path svdmodels_LANLTP1 --interpolation-type tensorflow --tmin 0. --tmax 21.0 --dt 0.1 --data-path lcs_lanl_TP_wind1 --tensorflow-nepochs 100 --outdir output_LANLTP1_tf --plot
+
+# model: LANLTP2
+# lightcurves: lcs_lanl_TP_wind2
+create-svdmodel --model LANLTP2 --svd-path svdmodels_LANLTP2 --interpolation-type tensorflow --tmin 0. --tmax 21.0 --dt 0.1 --data-path lcs_lanl_TP_wind2 --tensorflow-nepochs 100 --outdir output_LANLTP2_tf --plot
 
 # model: Bu2019lm
 # lightcurves: lcs_bulla_2019_bns
@@ -16,7 +28,7 @@ create-svdmodel --model Bu2019nsbh --svd-path svdmodels_Bu2019nsbh --interpolati
 # lightcurves: lcs_bulla_2022
 create-svdmodel --model Bu2022Ye --svd-path svdmodels_Bu2022Ye --interpolation-type tensorflow --tmin 0. --tmax 21.0 --dt 0.1 --data-path lcs_bulla_2022 --tensorflow-nepochs 100 --outdir output_Bu2022Ye_tf --plot
 
-# model: Bu2022Ye
+# model: Bu2023Ye
 # lightcurves: lcs_bulla_2023
 create-svdmodel --model Bu2023Ye --svd-path svdmodels_Bu2023Ye --interpolation-type tensorflow --tmin 0. --tmax 21.0 --dt 0.1 --data-path lcs_bulla_2023 --tensorflow-nepochs 100 --outdir output_Bu2023Ye_tf --plot
 


### PR DESCRIPTION
This PR updates the model list and documentation to remove LANL2022 in favor of the specific morphologies: LANLTS1, LANLTS2, LANLTP1, and LANLTP2. The original LANL2022 model was trained on all four morphologies and thus produced unphysical results. The trained LANL2022 models have also been removed from gitlab, and the four morphologies have been added.

Note that `LANL2022.prior` remains in place, since it can be used in sampling for any of the morphologies.