### PR TITLE
add `rst` linter

### DIFF
--- a/.github/workflows/rst-linter.yml
+++ b/.github/workflows/rst-linter.yml
@@ -1,0 +1,20 @@
+name: Lint
+
+on:
+    push:
+    pull_request:
+
+jobs:
+    doctor-rst:
+        name: DOCtor-RST
+        runs-on: ubuntu-latest
+        steps:
+            - name: "Checkout code"
+              uses: actions/checkout@v4
+
+            - name: DOCtor-RST
+              uses: docker://oskarstark/doctor-rst
+              with:
+                  args: --short --error-format=github
+              env:
+                  DOCS_DIR: 'doc/'

--- a/.github/workflows/rst-linter.yml
+++ b/.github/workflows/rst-linter.yml
@@ -3,6 +3,8 @@ name: Lint rst
 on:
     push:
         paths: ['**/**.rst']
+    pull_request:
+        paths: ['**/**.rst']
 
 jobs:
     doctor-rst:

--- a/.github/workflows/rst-linter.yml
+++ b/.github/workflows/rst-linter.yml
@@ -1,7 +1,8 @@
-name: Lint
+name: Lint rst
 
 on:
     push:
+        paths: ['**/**.rst']
 
 jobs:
     doctor-rst:

--- a/.github/workflows/rst-linter.yml
+++ b/.github/workflows/rst-linter.yml
@@ -2,7 +2,6 @@ name: Lint
 
 on:
     push:
-        paths: ['**/**.rst']
 
 jobs:
     doctor-rst:

--- a/.github/workflows/rst-linter.yml
+++ b/.github/workflows/rst-linter.yml
@@ -2,7 +2,7 @@ name: Lint
 
 on:
     push:
-    pull_request:
+        paths: ['**/**.rst']
 
 jobs:
     doctor-rst:

--- a/doc/.doctor-rst.yaml
+++ b/doc/.doctor-rst.yaml
@@ -1,5 +1,4 @@
 rules:
-    blank_line_after_directive: ~
+    blank_line_after_directive: 
 exclude_rule_for_file:
     - path: doc/changelog.rst
-      rule_name: blank_line_after_directive

--- a/doc/.doctor-rst.yaml
+++ b/doc/.doctor-rst.yaml
@@ -1,2 +1,5 @@
 rules:
     blank_line_after_directive: ~
+exclude_rule_for_file:
+    - path: doc/changelog.rst
+      rule_name: blank_line_after_directive

--- a/doc/.doctor-rst.yaml
+++ b/doc/.doctor-rst.yaml
@@ -1,4 +1,5 @@
 rules:
-    blank_line_after_directive: 
+    blank_line_after_directive: ~
 exclude_rule_for_file:
-    - path: doc/changelog.rst
+    - path: changelog.rst
+      rule_name: blank_line_after_directive

--- a/doc/.doctor-rst.yaml
+++ b/doc/.doctor-rst.yaml
@@ -1,0 +1,2 @@
+rules:
+    blank_line_after_directive: ~

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -3,7 +3,6 @@ Changelog
 
 
 .. changelog::
-
     :github: https://github.com/nuclear-multimessenger-astronomy/nmma/releases/
     :pypi: https://pypi.org/project/nmma/
     :changelog-url: https://nuclear-multimessenger-astronomy.github.io/nmma/changelog.html

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -3,6 +3,7 @@ Changelog
 
 
 .. changelog::
+
     :github: https://github.com/nuclear-multimessenger-astronomy/nmma/releases/
     :pypi: https://pypi.org/project/nmma/
     :changelog-url: https://nuclear-multimessenger-astronomy.github.io/nmma/changelog.html

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -208,6 +208,7 @@ requirements.txt file which are necessary for NMMA:
    If everything has gone smoothly, all of these above mentioned "pip install something" commands will show that the requirements have already been satisfied. Otherwise, these will cover the dependencies if not covered by ``pip install .``. Also, if running ``pip install .`` shows something on the lines of "cannot cythonize without cython", do:
 
 .. code::
+
    conda install -c anaconda cython==0.29.24
    pip install
 
@@ -415,12 +416,14 @@ Internetless Clusters
 Some cluster resources may not have access to the internet or could block some forms of data transfer. This will cause some difficulties with certain packages and will require some fixes to how NMMA interacts with them and changes to how you call some commands in NMMA. This can also affect how you install NMMA on the cluster. Because the cluster is in some way restricted, it may be that the `conda install nmma -c conda-forge` or the `pip install nmma` commands don't work. Thus to install NMMA, you will need to install from the source. To begin, you will want to copy the NMMA repository from your local to the cluster using an `scp` or `rsync` commmand because likely the git commands will fail. Once NMMA is downloaded to the cluster, navigate to the main directory and run
 
 .. code::
+
    pip install -r requirements.txt
    pip install .
 
 and check that the installation was successful by running the first check for NMMA given above. After installation, the next most likely difference is how NMMA uses the trained kilonova models during any form of EM analysis. When running any analysis that requires the use of the trained grid of models you will need to add the `--local-only` flag to the analysis command. For example,
 
 .. code::
+
    lightcurve-analysis \
         --model LANLTP2 \
         --svd-path svdmodels/ \


### PR DESCRIPTION
Since not everyone is familiar with `rst` and directives. It is beneficial to have a `rst` linter in order to prevent incorrect docs being pushed to documentation. This only runs whenever a `rst` file is changed. 