### PR TITLE
Remove pound sign in dat/csv file lightcurves

### DIFF
--- a/nmma/em/create_lightcurves.py
+++ b/nmma/em/create_lightcurves.py
@@ -356,7 +356,7 @@ def main(args=None):
                 fid = open(injection_outfile, "w")
                 # fid.write('# t[days] u g r i z y J H K\n')
                 # fid.write(str(" ".join(('# t[days]'," ".join(args.filters.split(',')),"\n"))))
-                fid.write("# t[days] ")
+                fid.write("t[days] ")
                 fid.write(str(" ".join(args.filters.split(","))))
                 fid.write("\n")
 


### PR DESCRIPTION
inclusion of '# ' in space separated lightcurve files is somewhat bothersome for loading in lightcurve files outside of nmma.

Not sure if this affects any other areas of the code if it removed