### PR TITLE
Fix pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,7 +78,7 @@ Download = "https://pypi.org/project/nmma/#files"
 Tracker = "https://github.com/nuclear-multimessenger-astronomy/nmma/issues"
 
 [tool.setuptools.packages.find]
-include = ["nmma*"]
+include = ["nmma*", "tools*"]
 
 [tool.setuptools.package-data]
 gwemopt = ['data/*/*']


### PR DESCRIPTION
When installing, it needs to look into the tools folder. This doesn't work with the new pyproject.toml. [probably worked with the old setup.py]