### PR TITLE
add support for time dependent (and filter dependent) systematic error

### DIFF
--- a/nmma/em/analysis.py
+++ b/nmma/em/analysis.py
@@ -420,6 +420,12 @@ def get_parser(**kwargs):
         action="store_true",
         default=False,
     )
+    parser.add_argument(
+        "--systematics-file",
+        metavar="PATH",
+        help="Path to systematics configuration file",
+        default=None,
+    )
 
     return parser
 
@@ -771,6 +777,7 @@ def analysis(args):
         error_budget=error_budget,
         verbose=args.verbose,
         detection_limit=args.detection_limit,
+        systematics_file=args.systematics_file
     )
 
     likelihood = OpticalLightCurve(**likelihood_kwargs)

--- a/nmma/em/analysis_lbol.py
+++ b/nmma/em/analysis_lbol.py
@@ -222,6 +222,13 @@ def get_parser(**kwargs):
         action="store_true",
         default=False,
     )
+    parser.add_argument( #no use in this script
+        "--systematics-file",
+        metavar="PATH",
+        help="Path to systematics configuration file",
+        default=None,
+    )
+
     return parser
 
 

--- a/nmma/em/prior.py
+++ b/nmma/em/prior.py
@@ -1,9 +1,31 @@
 import bilby
 import bilby.core
 from bilby.core.prior import Prior
+from bilby.core.prior import PriorDict as _PriorDict
 from bilby.core.prior.interpolated import Interped
 from bilby.core.prior.conditional import ConditionalTruncatedGaussian
 
+from . import systematics
+
+def from_list(self, systematics):
+    """
+    Similar to `from_file` but instead of file buffer, takes a list of Prior strings
+    See `from_file` for more details
+    """
+
+    comments = ["#", "\n"]
+    prior = dict()
+    for line in systematics:
+        if line[0] in comments:
+            continue
+        line.replace(" ", "")
+        elements = line.split("=")
+        key = elements[0].replace(" ", "")
+        val = "=".join(elements[1:]).strip()
+        prior[key] = val
+    self.from_dictionary(prior)
+
+setattr(_PriorDict, "from_list", from_list)
 
 class ConditionalGaussianIotaGivenThetaCore(ConditionalTruncatedGaussian):
     """
@@ -264,4 +286,7 @@ def create_prior_from_args(model_names, args):
 
         print(f"The prior on Ebv is set to fixed value of {priors['Ebv']}")
 
+    if args.systematics_file is not None:
+        systematics_priors = systematics.main(args.systematics_file)
+        priors.from_list(systematics_priors)
     return priors

--- a/nmma/em/systematics.py
+++ b/nmma/em/systematics.py
@@ -1,0 +1,179 @@
+import yaml
+from pathlib import Path
+import warnings
+
+warnings.simplefilter("module", DeprecationWarning)
+
+
+class ValidationError(ValueError):
+    def __init__(self, key, message):
+        super().__init__(f"Validation error for '{key}': {message}")
+
+
+ALLOWED_FILTERS = [
+    "2massh",
+    "2massj",
+    "2massks",
+    "atlasc",
+    "atlaso",
+    "bessellb",
+    "besselli",
+    "bessellr",
+    "bessellux",
+    "bessellv",
+    "ps1__g",
+    "ps1__i",
+    "ps1__r",
+    "ps1__y",
+    "ps1__z",
+    "sdssu",
+    "uvot__b",
+    "uvot__u",
+    "uvot__uvm2",
+    "uvot__uvw1",
+    "uvot__uvw2",
+    "uvot__v",
+    "uvot__white",
+    "ztfg",
+    "ztfi",
+    "ztfr",
+]
+
+
+def load_yaml(file_path):
+    return yaml.safe_load(Path(file_path).read_text())
+
+
+def validate_only_one_true(yaml_dict):
+    for key, values in yaml_dict["config"].items():
+        if "value" not in values or type(values["value"]) is not bool:
+            raise ValidationError(
+                key, "'value' key must be present and be a boolean"
+            )
+    true_count = sum(value["value"] for value in yaml_dict["config"].values())
+    if true_count > 1:
+        raise ValidationError(
+            "config", "Only one configuration key can be set to True at a time"
+        )
+    elif true_count == 0:
+        raise ValidationError(
+            "config", "At least one configuration key must be set to True"
+        )
+
+
+def validate_filters(filter_groups):
+    used_filters = set()
+    for filter_group in filter_groups:
+        if isinstance(filter_group, list):
+            filters_in_group = set()  # Keep track of filters within this group
+            for filt in filter_group:
+                if filt not in ALLOWED_FILTERS:
+                    raise ValidationError(
+                        "filters",
+                        f"Invalid filter value '{filt}'. Allowed values are {', '.join([str(f) for f in ALLOWED_FILTERS])}",
+                    )
+                if filt in filters_in_group:
+                    raise ValidationError(
+                        "filters",
+                        f"Duplicate filter value '{filt}' within the same group.",
+                    )
+                if filt in used_filters:
+                    raise ValidationError(
+                        "filters",
+                        f"Duplicate filter value '{filt}'. A filter can only be used in one group.",
+                    )
+                used_filters.add(filt)
+                filters_in_group.add(filt)
+                # Add the filter to the set of used filters within this group
+        elif filter_group is not None and filter_group not in ALLOWED_FILTERS:
+            raise ValidationError(
+                "filters",
+                f"Invalid filter value '{filter_group}'. Allowed values are {', '.join([str(f) for f in ALLOWED_FILTERS])}",
+            )
+        elif filter_group in used_filters:
+            raise ValidationError(
+                "filters",
+                f"Duplicate filter value '{filter_group}'. A filter can only be used in one group.",
+            )
+        else:
+            used_filters.add(filter_group)
+
+
+def validate_distribution(distribution):
+    if distribution != "Uniform":
+        raise ValidationError(
+            "type",
+            f"Invalid distribution '{distribution}'. Only 'Uniform' distribution is supported",
+        )
+
+
+def validate_fields(key, values, required_fields):
+    missing_fields = [
+        field for field in required_fields if values.get(field) is None
+    ]
+    if missing_fields:
+        raise ValidationError(
+            key, f"Missing fields: {', '.join(missing_fields)}"
+        )
+    for field, expected_type in required_fields.items():
+        if not isinstance(values[field], expected_type):
+            raise ValidationError(
+                key, f"'{field}' must be of type {expected_type}"
+            )
+
+
+def handle_withTime(key, values):
+    required_fields = {
+        "type": str,
+        "min": (float, int),
+        "max": (float, int),
+        "time_nodes": int,
+        "filters": list,
+    }
+
+
+    validate_fields(key, values, required_fields)
+    filter_groups = values.get("filters", [])
+    validate_filters(filter_groups)
+    distribution = values.get("type")
+    validate_distribution(distribution)
+    result = []
+
+    for filter_group in filter_groups:
+        if isinstance(filter_group, list):
+            filter_name = "___".join(filter_group)
+        else:
+            filter_name = filter_group if filter_group is not None else "all"
+
+        for n in range(1, values["time_nodes"] + 1):
+            result.append(
+                f'sys_err_{filter_name}{n} = {values["type"]}(minimum={values["min"]},maximum={values["max"]},name="sys_err_{filter_name}{n}")'
+            )
+
+    return result
+
+
+def handle_withoutTime(key, values):
+    required_fields = {"type": str, "min": (float, int), "max": (float, int)}
+    validate_fields(key, values, required_fields)
+    distribution = values.get("type")
+    validate_distribution(distribution)
+    return [
+        f'sys_err = {values["type"]}(minimum={values["min"]},maximum={values["max"]},name="sys_err")'
+    ]
+
+
+config_handlers = {
+    "withTime": handle_withTime,
+    "withoutTime": handle_withoutTime,
+}
+
+
+def main(yaml_file_path):
+    yaml_dict = load_yaml(yaml_file_path)
+    validate_only_one_true(yaml_dict)
+    results = []
+    for key, values in yaml_dict["config"].items():
+        if values["value"] and key in config_handlers:
+            results.extend(config_handlers[key](key, values))
+    return results

--- a/nmma/tests/analysis.py
+++ b/nmma/tests/analysis.py
@@ -1,6 +1,7 @@
 from argparse import Namespace
 import os
 import pytest
+import shutil
 
 
 from ..em import analysis
@@ -9,6 +10,13 @@ from tools import analysis_slurm
 
 WORKING_DIR = os.path.dirname(__file__)
 DATA_DIR = os.path.join(WORKING_DIR, "data")
+
+
+@pytest.fixture(autouse=True)
+def cleanup_outdir(args):
+    yield
+    if os.path.exists(args.outdir):
+        shutil.rmtree(args.outdir)
 
 
 @pytest.fixture(scope="module")

--- a/nmma/tests/analysis.py
+++ b/nmma/tests/analysis.py
@@ -10,6 +10,7 @@ from tools import analysis_slurm
 WORKING_DIR = os.path.dirname(__file__)
 DATA_DIR = os.path.join(WORKING_DIR, "data")
 
+
 @pytest.fixture(scope="module")
 def args():
     args = Namespace(
@@ -46,7 +47,7 @@ def args():
         injection_outfile="outdir/lc.csv",
         injection_model=None,
         ignore_timeshift=False,
-	remove_nondetections=True,
+        remove_nondetections=True,
         detection_limit=None,
         with_grb_injection=False,
         prompt_collapse=False,
@@ -77,10 +78,22 @@ def args():
         cosiota_node_num=10,
         ra=None,
         dec=None,
-        fetch_Ebv_from_dustmap=False
+        fetch_Ebv_from_dustmap=False,
     )
 
     return args
+
+
+def test_analysis_systematics_with_time(args):
+
+    args.systematics_file = f"{DATA_DIR}/systematics_with_time.yaml"
+    analysis.main(args)
+
+
+def test_analysis_systematics_without_time(args):
+
+    args.systematics_file = f"{DATA_DIR}/systematics_without_time.yaml"
+    analysis.main(args)
 
 
 def test_analysis_tensorflow(args):
@@ -93,6 +106,7 @@ def test_analysis_sklearn_gp(args):
     args.interpolation_type = "sklearn_gp"
     analysis.main(args)
 
+
 def test_nn_analysis(args):
 
     args.model = "Ka2017"
@@ -101,8 +115,9 @@ def test_nn_analysis(args):
     args.dt = 0.25
     args.filters = "ztfg,ztfr,ztfi"
     args.local_only = False
-    args.injection=f"{DATA_DIR}/Ka2017_injection.json"
+    args.injection = f"{DATA_DIR}/Ka2017_injection.json"
     analysis.main(args)
+
 
 def test_analysis_slurm(args):
 

--- a/nmma/tests/analysis_lbol.py
+++ b/nmma/tests/analysis_lbol.py
@@ -44,7 +44,8 @@ def args():
         cosiota_node_num=10,
         ra=None,
         dec=None,
-        fetch_Ebv_from_dustmap=False
+        fetch_Ebv_from_dustmap=False,
+        systematics_file=None
     )
 
     return args

--- a/nmma/tests/data/systematics_with_time.yaml
+++ b/nmma/tests/data/systematics_with_time.yaml
@@ -1,0 +1,14 @@
+config:
+  withTime:
+    value: true
+    filters:
+      - null # you can keep it or remove it, it will still be parsed as None (filter independent)
+    time_nodes: 4
+    type: "Uniform"
+    min: 0
+    max: 2
+  withoutTime:
+    value: false
+    type: "Uniform"
+    min: 0
+    max: 2

--- a/nmma/tests/data/systematics_without_time.yaml
+++ b/nmma/tests/data/systematics_without_time.yaml
@@ -1,0 +1,14 @@
+config:
+  withTime:
+    value: false
+    filters:
+      - null # you can keep it or remove it, it will still be parsed as None (filter independent)
+    time_nodes: 4
+    type: "Uniform"
+    min: 0
+    max: 2
+  withoutTime:
+    value: true
+    type: "Uniform"
+    min: 0
+    max: 2

--- a/nmma/tests/systematics.py
+++ b/nmma/tests/systematics.py
@@ -1,0 +1,237 @@
+from pathlib import Path
+import pytest
+
+import yaml
+from ..em.systematics import (
+    ValidationError,
+    validate_only_one_true,
+    validate_filters,
+    validate_distribution,
+    validate_fields,
+    handle_withTime,
+    handle_withoutTime,
+    main,
+    ALLOWED_FILTERS,
+)
+
+
+@pytest.fixture
+def sample_yaml_content():
+    return """
+config:
+  withTime:
+    value: true
+    type: Uniform
+    min: 0.0
+    max: 1.0
+    time_nodes: 2
+    filters:
+      - [bessellb, bessellv]
+      - ztfr
+  withoutTime:
+    value: false
+    type: Uniform
+    min: 0.0
+    max: 1.0
+"""
+
+
+@pytest.fixture
+def sample_yaml_file(tmp_path, sample_yaml_content):
+    yaml_file = tmp_path / "test_config.yaml"
+    yaml_file.write_text(sample_yaml_content)
+    return yaml_file
+
+
+def test_validate_only_one_true_valid(sample_yaml_file):
+    yaml_dict = yaml.safe_load(Path(sample_yaml_file).read_text())
+    validate_only_one_true(yaml_dict)  # Should not raise an exception
+
+
+def test_validate_only_one_true_invalid():
+    invalid_yaml = {"config": {"withTime": {"value": True}, "withoutTime": {"value": True}}}
+    with pytest.raises(ValidationError, match="Only one configuration key can be set to True at a time"):
+        validate_only_one_true(invalid_yaml)
+
+
+def test_validate_filters_valid():
+    valid_filters = [["bessellb", "bessellv"], "ztfr"]
+    validate_filters(valid_filters)  # Should not raise an exception
+
+
+def test_validate_filters_invalid():
+    invalid_filters = [["bessellb", "invalid_filter"], "ztfr"]
+    with pytest.raises(ValidationError, match="Invalid filter value 'invalid_filter'"):
+        validate_filters(invalid_filters)
+
+
+def test_validate_distribution_valid():
+    validate_distribution("Uniform")  # Should not raise an exception
+
+
+def test_validate_distribution_invalid():
+    with pytest.raises(ValidationError, match="Invalid distribution 'Normal'"):
+        validate_distribution("Normal")
+
+
+def test_validate_fields_valid():
+    valid_values = {"type": "Uniform", "min": 0.0, "max": 1.0}
+    required_fields = {"type": str, "min": (float, int), "max": (float, int)}
+    validate_fields("test", valid_values, required_fields)  # Should not raise an exception
+
+
+def test_validate_fields_invalid():
+    invalid_values = {"type": "Uniform", "min": "0.0", "max": 1.0}
+    required_fields = {"type": str, "min": (float, int), "max": (float, int)}
+    with pytest.raises(ValidationError, match="'min' must be of type"):
+        validate_fields("test", invalid_values, required_fields)
+
+
+def test_handle_withTime():
+    values = {"type": "Uniform", "min": 0.0, "max": 1.0, "time_nodes": 2, "filters": [["bessellb", "bessellv"], "ztfr"]}
+    result = handle_withTime("withTime", values)
+    assert "sys_err_bessellb___bessellv1" in result[0]
+    assert "sys_err_ztfr2" in result[3]
+
+
+def test_handle_withoutTime():
+    values = {"type": "Uniform", "min": 0.0, "max": 1.0}
+    result = handle_withoutTime("withoutTime", values)
+    assert len(result) == 1
+    assert 'sys_err = Uniform(minimum=0.0,maximum=1.0,name="sys_err")' in result[0]
+
+
+def test_main(sample_yaml_file):
+    result = main(sample_yaml_file)
+    assert all("sys_err" in line for line in result)
+
+
+def test_main_invalid_yaml(tmp_path):
+    invalid_yaml = tmp_path / "invalid_config.yaml"
+    invalid_yaml.write_text("invalid: yaml: content")
+    with pytest.raises(yaml.YAMLError):
+        main(invalid_yaml)
+
+
+def test_validate_only_one_true_all_false():
+    invalid_yaml = {"config": {"withTime": {"value": False}, "withoutTime": {"value": False}}}
+    with pytest.raises(ValidationError, match="At least one configuration key must be set to True"):
+        validate_only_one_true(invalid_yaml)
+
+
+def test_validate_only_one_true_missing_value():
+    invalid_yaml = {"config": {"withTime": {}, "withoutTime": {"value": False}}}
+    with pytest.raises(ValidationError, match="'value' key must be present and be a boolean"):
+        validate_only_one_true(invalid_yaml)
+
+
+def test_validate_filters_duplicate_in_group():
+    invalid_filters = [["bessellb", "bessellb"], "ztfr"]
+    with pytest.raises(ValidationError, match="Duplicate filter value 'bessellb' within the same group"):
+        validate_filters(invalid_filters)
+
+
+def test_validate_filters_duplicate_across_groups():
+    invalid_filters = [["bessellb", "bessellv"], "bessellb"]
+    with pytest.raises(ValidationError, match="Duplicate filter value 'bessellb'. A filter can only be used in one group"):
+        validate_filters(invalid_filters)
+
+
+def test_validate_filters_none_value():
+    valid_filters = [["bessellb", "bessellv"], None]
+    validate_filters(valid_filters)  # Should not raise an exception
+
+
+def test_validate_filters_empty_list():
+    validate_filters([])  # Should not raise an exception
+
+
+def test_validate_distribution_case_sensitive():
+    with pytest.raises(ValidationError, match="Invalid distribution 'uniform'"):
+        validate_distribution("uniform")  # Should be "Uniform"
+
+
+@pytest.mark.parametrize("invalid_type", [123, True, [], {}])
+def test_validate_fields_invalid_types(invalid_type):
+    invalid_values = {"type": invalid_type, "min": 0.0, "max": 1.0}
+    required_fields = {"type": str, "min": (float, int), "max": (float, int)}
+    with pytest.raises(ValidationError, match="'type' must be of type"):
+        validate_fields("test", invalid_values, required_fields)
+
+
+def test_handle_withTime_single_filter():
+    values = {"type": "Uniform", "min": 0.0, "max": 1.0, "time_nodes": 2, "filters": ["ztfr"]}
+    result = handle_withTime("withTime", values)
+    assert len(result) == 2
+    assert all("sys_err_ztfr" in line for line in result)
+
+
+def test_handle_withTime_all_filters():
+    values = {"type": "Uniform", "min": 0.0, "max": 1.0, "time_nodes": 1, "filters": [None]}
+    result = handle_withTime("withTime", values)
+    assert len(result) == 1
+    assert "sys_err_all1" in result[0]
+
+
+def test_handle_withTime_integer_bounds():
+    values = {"type": "Uniform", "min": 0, "max": 10, "time_nodes": 1, "filters": ["ztfr"]}
+    result = handle_withTime("withTime", values)
+    assert "minimum=0" in result[0] and "maximum=10" in result[0]
+
+
+def test_handle_withoutTime_integer_bounds():
+    values = {"type": "Uniform", "min": 0, "max": 10}
+    result = handle_withoutTime("withoutTime", values)
+    assert "minimum=0" in result[0] and "maximum=10" in result[0]
+
+
+def test_main_withoutTime(tmp_path):
+    yaml_content = """
+config:
+  withTime:
+    value: false
+  withoutTime:
+    value: true
+    type: Uniform
+    min: 0.0
+    max: 1.0
+"""
+    yaml_file = tmp_path / "withoutTime_config.yaml"
+    yaml_file.write_text(yaml_content)
+    result = main(yaml_file)
+    assert len(result) == 1
+    assert "sys_err = Uniform" in result[0]
+
+
+def test_main_empty_config(tmp_path):
+    yaml_content = """
+config:
+  withTime:
+    value: false
+  withoutTime:
+    value: false
+"""
+    yaml_file = tmp_path / "empty_config.yaml"
+    yaml_file.write_text(yaml_content)
+    with pytest.raises(ValidationError, match="At least one configuration key must be set to True"):
+        main(yaml_file)
+
+
+@pytest.mark.parametrize("filter_name", ALLOWED_FILTERS)
+def test_all_allowed_filters(filter_name):
+    values = {"type": "Uniform", "min": 0.0, "max": 1.0, "time_nodes": 1, "filters": [filter_name]}
+    result = handle_withTime("withTime", values)
+    assert len(result) == 1
+    assert f"sys_err_{filter_name}1" in result[0]
+
+
+def test_load_yaml_file_not_found():
+    with pytest.raises(FileNotFoundError):
+        main("non_existent_file.yaml")
+
+
+def test_load_yaml_invalid_format(tmp_path):
+    invalid_yaml = tmp_path / "invalid_format.yaml"
+    invalid_yaml.write_text("{ invalid: yaml: content")
+    with pytest.raises(yaml.YAMLError):
+        main(invalid_yaml)

--- a/priors/systematics.yaml
+++ b/priors/systematics.yaml
@@ -1,0 +1,19 @@
+#boilerplate for systematics prior
+
+config:
+  withTime:
+    value: true
+    filters:
+      - sdssu
+      - 2massks
+      - [2massj, 2massh]
+      - null # you can keep it or remove it, it will still be parsed as None (filter independent)
+    time_nodes: 2
+    type: "Uniform"
+    min: 0
+    max: 2
+  withoutTime:
+    value: false
+    type: "Uniform"
+    min: 0
+    max: 2


### PR DESCRIPTION
Copy of #253 

This PR adds support for sampled systematic error and time (and filter) dependent (interpolated) systematic error. For optimum performance it is recommended that the filters to be used for systematic biases should be less than or equal to the no of filters being used for the inference. If the no of filters for systematic biases is more than the no of `--filters` then the sampler will unnecessarily sample the priors which are of no use. For eg. if the filters in `--filters` is `sdssu,ps1__g,ps1__r,ps1__i,ps1__z,ps1__y,2massj,2massh,2massks` and you want to independently sample `ps1__r` and `ps1__i` filters then the yaml should be

```yaml
config:
  withTime:
    value: true
    filters: ["ps1__r", "ps1__i", null]
    ...
    ...
```
null will be a single array which will be used for all other filters excluding `ps1__r` and `ps1__i`.

The option is still there to add the systematic error in the prior file, however changed the name of the prior to be `sys_err`