### PR TITLE
Fix docker python

### DIFF
--- a/.github/workflows/build-deploy-container.yml
+++ b/.github/workflows/build-deploy-container.yml
@@ -3,6 +3,7 @@ name: CI to Docker Hub
 on:
   push:
     branches: [ main ]
+  workflow_dispatch:
 env:
   REGISTRY_IMAGE: nmma/nmma_api
 

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -8,8 +8,8 @@ COPY requirements.txt .
 RUN mamba env create -f environment.yml
 RUN conda clean -afy
 RUN find -name '__pycache__' -type d -exec rm -rf '{}' '+'
-RUN rm -rf /opt/conda/envs/nmma/lib/python3.9/site-packages/pip
-RUN rm -rf /opt/conda/envs/nmma/lib/python3.9/i{dlelib, ensurepip}
+RUN rm -rf /opt/conda/envs/nmma/lib/python3.12/site-packages/pip
+RUN rm -rf /opt/conda/envs/nmma/lib/python3.12/i{dlelib, ensurepip}
 RUN rm -rf /opt/conda/envs/nmma/lib{a,t,l,u}san.so
 RUN find -name '*.a' -delete
 

--- a/api/environment.yml
+++ b/api/environment.yml
@@ -4,7 +4,7 @@ channels:
 - conda-forge
 
 dependencies:
-- python=3.9.*
+- python=3.12.*
 - numpy
 - numcodecs
 - h5py


### PR DESCRIPTION
This pull request updates the Docker Python environment to use Python 3.12 instead of Python 3.9 and makes related adjustments to the Docker build and continuous integration workflow. Also adds `workflow_dispatch` to manually trigger the build.