### PR TITLE
Fix: conversion.py

### DIFF
--- a/nmma/joint/conversion.py
+++ b/nmma/joint/conversion.py
@@ -176,7 +176,7 @@ class NSBHEjectaFitting(object):
             * (1.0 - 2.0 * compactness_2)
             / compactness_2
         )
-        mdyn += -a2 * np.power(mass_ratio_invert, n2) * (risco/mass_1_source) + a4
+        mdyn += -a2 * np.power(mass_ratio_invert, n2) * risco + a4
         mdyn *= baryon_mass_2
 
         mdyn = np.maximum(0.0, mdyn)


### PR DESCRIPTION
fix equation for total_mass_source in line 190 and another bug in line 179 where risco has to be divided by mass_1_source according to the paper referenced in line 164