### PR TITLE
BNS parameter conversion in GWTransientLikelihood

### DIFF
--- a/nmma/core/conversion.py
+++ b/nmma/core/conversion.py
@@ -11,6 +11,7 @@ from bilby.gw.conversion import (
     component_masses_to_symmetric_mass_ratio,
     lambda_1_lambda_2_to_lambda_tilde,
     convert_to_lal_binary_black_hole_parameters,
+    convert_to_lal_binary_neutron_star_parameters,
     generate_mass_parameters,
     chirp_mass_and_mass_ratio_to_total_mass
 )
@@ -130,6 +131,11 @@ def observation_angle_conversion(parameters):
 def bbh_source_frame(params):
     """Convert parameters to BBH parameters using bilby function."""
     params, _ = convert_to_lal_binary_black_hole_parameters(params)
+    return source_frame_masses(params)
+
+def bns_source_frame(params):
+    """Convert parameters to BNS parameters using bilby function."""
+    params, _ = convert_to_lal_binary_neutron_star_parameters(params)
     return source_frame_masses(params)
 
 def mass_ratio_to_eta(q):

--- a/nmma/gw/gw_likelihood.py
+++ b/nmma/gw/gw_likelihood.py
@@ -206,11 +206,10 @@ class GravitationalWaveTransientLikelihood(NMMALikelihood):
 
         super().__init__(gw_transient, priors)
 
-    def parameter_conversion(self, parameters):
         if "neutron_star" in self.sub_model.waveform_generator.frequency_domain_source_model.__name__:
-            return bns_source_frame(parameters)
+            self.parameter_conversion = bns_source_frame
         else:
-            return bbh_source_frame(parameters)
+            self.parameter_conversion = bbh_source_frame
     
     def posterior_conversion(self, posterior_samples):
         if "chi_eff" not in posterior_samples:

--- a/nmma/gw/gw_likelihood.py
+++ b/nmma/gw/gw_likelihood.py
@@ -1,8 +1,9 @@
 import numpy as np
 from ast import literal_eval
 from bilby.gw.likelihood import GravitationalWaveTransient, ROQGravitationalWaveTransient, RelativeBinningGravitationalWaveTransient, MBGravitationalWaveTransient
+from bilby.gw.source import binary_neutron_star_frequency_sequence
 from ..core.base import NMMALikelihood, initialisation_args_from_signature_and_namespace
-from ..core.conversion import (bbh_source_frame, tidal_deformabilities_and_mass_ratio_to_eff_tidal_deformabilities as tidal_conversion)
+from ..core.conversion import (bbh_source_frame, bns_source_frame, tidal_deformabilities_and_mass_ratio_to_eff_tidal_deformabilities as tidal_conversion)
 
 def setup_gw_kwargs(data_dump, args, logger, **kwargs):
     """
@@ -206,7 +207,10 @@ class GravitationalWaveTransientLikelihood(NMMALikelihood):
         super().__init__(gw_transient, priors)
 
     def parameter_conversion(self, parameters):
-        return bbh_source_frame(parameters)
+        if "neutron_star" in self.sub_model.waveform_generator.frequency_domain_source_model.__name__:
+            return bns_source_frame(parameters)
+        else:
+            return bbh_source_frame(parameters)
     
     def posterior_conversion(self, posterior_samples):
         if "chi_eff" not in posterior_samples:


### PR DESCRIPTION
Added the bns_source_frame function to conversion.py

GWTransientLikelihood now either has the BNS parameter conversion or BBH parameter conversion depending on the waveform generator.