### PR TITLE
Bug fix: filters could be None

### DIFF
--- a/nmma/em/analysis.py
+++ b/nmma/em/analysis.py
@@ -96,7 +96,6 @@ def bolometric_setup(args):
 def analysis_setup(args):
 
     filters = utils.set_filters(args)
-    detection_limit = utils.create_detection_limit(args, filters)
         
     try:
         # load observational data
@@ -105,7 +104,8 @@ def analysis_setup(args):
         injection_parameters = None
     except ValueError:
         # try to work with injection data instead
-        data, injection_parameters = data_from_injection(args, filters, detection_limit)
+        detection_limit = utils.create_detection_limit(args, filters)
+        data, injection_parameters = data_from_injection(args, filters)
         trigger_time = injection_parameters.get('trigger_time',0)
     except FileNotFoundError:
         # If the injection file is not found, raise an error
@@ -114,6 +114,7 @@ def analysis_setup(args):
     data = utils.cut_data_to_time_range(data, args, trigger_time)
     data = check_detections(data, args.remove_nondetections)
     filters_to_analyze = set_analysis_filters(filters, data)
+    detection_limit = utils.create_detection_limit(args, filters_to_analyze)
 
     # initialize light curve model
     print("Creating light curve model for inference")

--- a/nmma/em/analysis.py
+++ b/nmma/em/analysis.py
@@ -105,7 +105,7 @@ def analysis_setup(args):
     except ValueError:
         # try to work with injection data instead
         detection_limit = utils.create_detection_limit(args, filters)
-        data, injection_parameters = data_from_injection(args, filters)
+        data, injection_parameters = data_from_injection(args, filters, detection_limit)
         trigger_time = injection_parameters.get('trigger_time',0)
     except FileNotFoundError:
         # If the injection file is not found, raise an error

--- a/nmma/em/io.py
+++ b/nmma/em/io.py
@@ -74,7 +74,8 @@ def read_lc_from_csv(filename, args, format):
     if "obs" in format:
         with open(filename, "r") as f:
             lines = [line.rstrip("\n") for line in f]
-            lines = filter(None, lines) #get non-empty lines
+            lines = filter(None, lines) # get non-empty lines
+            lines = filter(lambda line: not line.startswith("#"), lines) # ignore lines that start with #
 
             data = {}
             for line in lines:


### PR DESCRIPTION
When doing an analysis, one should be able to leave the filters unspecified, so that in the end just the filters from the data are taken. This happens later, when filters_to_analyze is determined. But before that, it tries to find a detection_limit depending on filter, which will fail if filter is not specified.

This edit fixes this, although I am not sure if it's in the most elegant way imaginable.