### PR TITLE
Fix issue in mass source conversion

### DIFF
--- a/nmma/core/conversion.py
+++ b/nmma/core/conversion.py
@@ -13,8 +13,9 @@ from bilby.gw.conversion import (
     convert_to_lal_binary_black_hole_parameters,
     convert_to_lal_binary_neutron_star_parameters,
     generate_mass_parameters,
-    chirp_mass_and_mass_ratio_to_total_mass
+    chirp_mass_and_mass_ratio_to_total_mass,
 )
+
 
 def val_to_scalar(val):
     """Convert single-value quantities to scalars for easier handling"""
@@ -25,81 +26,104 @@ def val_to_scalar(val):
         if val.size == 1:
             return val.item()
         return val
-    
-########################## distance conversions ####################################
-def distance_modulus_nmma(d_lum = 1e-5):
-        # mag_app = mag_abs + 5* log10(dist/10pc) | NMMA-dist is in Mpc
-        #         = mag_abs + 5 * (log10(Mpc/10pc)+ log10(params["luminosity_distance"]))  
-        # therefore: distance_modulus = mag_app - mag_abs =
-        return  5.0 * (5+ np.log10(d_lum))
 
-def luminosity_distance_to_redshift(distance, cosmology = None):
+
+# =================== distance conversions # ===================
+def distance_modulus_nmma(d_lum=1e-5):
+    # mag_app = mag_abs + 5* log10(dist/10pc) | NMMA-dist is in Mpc
+    #         = mag_abs + 5 * (log10(Mpc/10pc)+ log10(params["luminosity_distance"]))
+    # therefore: distance_modulus = mag_app - mag_abs =
+    return 5.0 * (5 + np.log10(d_lum))
+
+
+def luminosity_distance_to_redshift(distance, cosmology=None):
     if cosmology is None:
         cosmology = get_cosmology()
     if isinstance(distance, pd.Series):
         distance = distance.values
 
-    if hasattr(distance, '__len__') and len(distance)>50: 
+    if hasattr(distance, "__len__") and len(distance) > 50:
         d_min, d_max = distance.min(), distance.max()
         dist_grid, z_grid = get_cosmo_grids(d_min, d_max, cosmology)
         return np.interp(distance, dist_grid, z_grid).value
     else:
-        return cosmo.z_at_value(cosmology.luminosity_distance, distance *units.Mpc).value
-        
+        return cosmo.z_at_value(
+            cosmology.luminosity_distance, distance * units.Mpc
+        ).value
+
+
 def get_cosmo_grids(distance_min, distance_max, cosmology):
-    #luminosity_distance_to_redshift gets really slow if too many distances are put in at once
+    # luminosity_distance_to_redshift gets really slow if too many distances are put in at once
     zmin = cosmo.z_at_value(cosmology.luminosity_distance, distance_min * units.Mpc)
     zmax = cosmo.z_at_value(cosmology.luminosity_distance, distance_max * units.Mpc)
     z_grid = np.geomspace(zmin, zmax, 50)
     dist_grid = cosmology.luminosity_distance(z_grid).value
     return dist_grid, z_grid
 
+
 def get_redshift(parameters):
     if "redshift" in parameters:
         return parameters["redshift"]
     elif "luminosity_distance" in parameters:
-            return luminosity_distance_to_redshift(parameters["luminosity_distance"])
+        return luminosity_distance_to_redshift(parameters["luminosity_distance"])
     else:
-        ## zeros like the first input of parameters, independent of size and keys
-        return np.zeros_like(next(iter(parameters.values()))) 
+        # zeros like the first input of parameters, independent of size and keys
+        return np.zeros_like(next(iter(parameters.values())))
+
 
 def cosmology_to_distance(parameters):
-    cosmology= get_cosmology()
+    cosmology = get_cosmology()
     cosmo_parameters = {}
     if "Hubble_constant" in parameters:
         cosmo_parameters["H0"] = parameters["Hubble_constant"]
     if "Omega_matter" in parameters:
         cosmo_parameters["Om0"] = parameters["Omega_matter"]
-    ## Maybe extend for an even wilder cosmology?
+    # Maybe extend for an even wilder cosmology?
     try:
         alt_cosmo = cosmology.clone(**cosmo_parameters)
         if "luminosity_distance" in parameters:
             # if luminosity distance is available, we assume it is in Mpc
             parameters["redshift"] = luminosity_distance_to_redshift(
-                parameters["luminosity_distance"], cosmology=alt_cosmo)
+                parameters["luminosity_distance"], cosmology=alt_cosmo
+            )
         elif "redshift" in parameters:
-            parameters["luminosity_distance"] = alt_cosmo.luminosity_distance(parameters["redshift"]).value
+            parameters["luminosity_distance"] = alt_cosmo.luminosity_distance(
+                parameters["redshift"]
+            ).value
         else:
-            raise KeyError("Either redshift or luminosity_distance must be in parameters")
+            raise KeyError(
+                "Either redshift or luminosity_distance must be in parameters"
+            )
 
     except ValueError:
         # if H0 is an array, .clone raises a ValueError
         # in that case we turn a dict with len-n values into a len-n list of dicts with single values
-        cosmo_dicts = [dict(zip(cosmo_parameters.keys(), vals)) for vals in zip(*cosmo_parameters.values())]
+        cosmo_dicts = [
+            dict(zip(cosmo_parameters.keys(), vals))
+            for vals in zip(*cosmo_parameters.values())
+        ]
         alt_cosmos = [cosmology.clone(**cosmo_dict) for cosmo_dict in cosmo_dicts]
 
-        if 'luminosity_distance' in parameters:
+        if "luminosity_distance" in parameters:
             # if luminosity distance is available, we assume it is in Mpc
             parameters["redshift"] = np.array(
-                [luminosity_distance_to_redshift(
-                    parameters["luminosity_distance"][i], cosmology=alt_cosmo) 
-                for i, alt_cosmo in enumerate(alt_cosmos)])
-            
+                [
+                    luminosity_distance_to_redshift(
+                        parameters["luminosity_distance"][i], cosmology=alt_cosmo
+                    )
+                    for i, alt_cosmo in enumerate(alt_cosmos)
+                ]
+            )
+
         elif "redshift" in parameters:
             parameters["luminosity_distance"] = np.array(
-                [alt_cosmo.luminosity_distance(parameters["redshift"][i]).value 
-                for i, alt_cosmo in enumerate(alt_cosmos)])
+                [
+                    alt_cosmo.luminosity_distance(parameters["redshift"][i]).value
+                    for i, alt_cosmo in enumerate(alt_cosmos)
+                ]
+            )
     return parameters
+
 
 def source_frame_masses(converted_parameters):
     converted_parameters = generate_mass_parameters(converted_parameters)
@@ -109,37 +133,52 @@ def source_frame_masses(converted_parameters):
     z = converted_parameters["redshift"]
 
     if "mass_1_source" not in converted_parameters:
-        converted_parameters["mass_1_source"] = np.array(converted_parameters["mass_1"] / (1 + z))
+        converted_parameters["mass_1_source"] = np.array(
+            converted_parameters["mass_1"] / (1 + z)
+        )
 
     if "mass_2_source" not in converted_parameters:
-        converted_parameters["mass_2_source"] = np.array(converted_parameters["mass_2"] / (1 + z))
+        converted_parameters["mass_2_source"] = np.array(
+            converted_parameters["mass_2"] / (1 + z)
+        )
 
     return converted_parameters
 
+
 def observation_angle_conversion(parameters):
-    theta_jn = parameters.get('theta_jn', np.arccos(parameters.get("cos_theta_jn", 1.)))
-    theta_jn = np.minimum(theta_jn, np.pi - theta_jn)  #default effective 0 if neither is given
+    theta_jn = parameters.get(
+        "theta_jn", np.arccos(parameters.get("cos_theta_jn", 1.0))
+    )
+    theta_jn = np.minimum(
+        theta_jn, np.pi - theta_jn
+    )  # default effective 0 if neither is given
     if "KNtheta" not in parameters:
-        parameters["KNtheta"] =  parameters.get("inclination_EM", theta_jn ) * 180.0 / np.pi
+        parameters["KNtheta"] = (
+            parameters.get("inclination_EM", theta_jn) * 180.0 / np.pi
+        )
     if "inclination_EM" not in parameters:
         parameters["inclination_EM"] = parameters["KNtheta"] / 180.0 * np.pi
     return parameters
 
 
-############################## mass conversions ####################################
+# =================== mass conversions  ===================
+
 
 def bbh_source_frame(params):
     """Convert parameters to BBH parameters using bilby function."""
     params, _ = convert_to_lal_binary_black_hole_parameters(params)
     return source_frame_masses(params)
 
+
 def bns_source_frame(params):
     """Convert parameters to BNS parameters using bilby function."""
     params, _ = convert_to_lal_binary_neutron_star_parameters(params)
     return source_frame_masses(params)
 
+
 def mass_ratio_to_eta(q):
     return q / (1 + q) ** 2
+
 
 def component_masses_to_mass_quantities(m1, m2):
     eta = m1 * m2 / ((m1 + m2) * (m1 + m2))
@@ -148,34 +187,52 @@ def component_masses_to_mass_quantities(m1, m2):
 
     return (mchirp, eta, q)
 
+
 def chirp_mass_and_eta_to_component_masses(mc, eta):
     """
     Utility function for converting mchirp,eta to component masses. The
     masses are defined so that m1>m2. The rvalue is a tuple (m1,m2).
     """
-    M = mc / np.power(eta, 3. / 5.)
-    q = (1 - np.sqrt(1. - 4. * eta) - 2 * eta) / (2. * eta)
+    M = mc / np.power(eta, 3.0 / 5.0)
+    q = (1 - np.sqrt(1.0 - 4.0 * eta) - 2 * eta) / (2.0 * eta)
 
-    m1 = M / (1. + q)
-    m2 = M * q / (1. + q)
+    m1 = M / (1.0 + q)
+    m2 = M * q / (1.0 + q)
 
     return (m1, m2)
 
-def tidal_deformabilities_and_mass_ratio_to_eff_tidal_deformabilities(lambda1, lambda2, q):
-    eta = q / np.power(1. + q, 2.)
+
+def tidal_deformabilities_and_mass_ratio_to_eff_tidal_deformabilities(
+    lambda1, lambda2, q
+):
+    eta = q / np.power(1.0 + q, 2.0)
     eta2 = eta * eta
     eta3 = eta2 * eta
-    root14eta = np.sqrt(1. - 4 * eta)
+    root14eta = np.sqrt(1.0 - 4 * eta)
 
-    lambdaT = (8. / 13.) * ((1. + 7 * eta - 31 * eta2) * (lambda1 + lambda2) + root14eta * (1. + 9 * eta - 11. * eta2) * (lambda1 - lambda2))
-    dlambdaT = 0.5 * (root14eta * (1. - 13272. * eta / 1319. + 8944. * eta2 / 1319.) * (lambda1 + lambda2) + (1. - 15910. * eta / 1319. + 32850. * eta2 / 1319. + 3380. * eta3 / 1319.) * (lambda1 - lambda2))
+    lambdaT = (8.0 / 13.0) * (
+        (1.0 + 7 * eta - 31 * eta2) * (lambda1 + lambda2)
+        + root14eta * (1.0 + 9 * eta - 11.0 * eta2) * (lambda1 - lambda2)
+    )
+    dlambdaT = 0.5 * (
+        root14eta
+        * (1.0 - 13272.0 * eta / 1319.0 + 8944.0 * eta2 / 1319.0)
+        * (lambda1 + lambda2)
+        + (
+            1.0
+            - 15910.0 * eta / 1319.0
+            + 32850.0 * eta2 / 1319.0
+            + 3380.0 * eta3 / 1319.0
+        )
+        * (lambda1 - lambda2)
+    )
 
     return lambdaT, dlambdaT
 
 
 def reweight_to_flat_mass_prior(df):
     total_mass = chirp_mass_and_mass_ratio_to_total_mass(df.chirp_mass, df.mass_ratio)
-    m1 = total_mass / (1. + df.mass_ratio)
+    m1 = total_mass / (1.0 + df.mass_ratio)
     jacobian = m1 * m1 / df.chirp_mass
     df_new = df.sample(frac=0.3, weights=jacobian)
     return df_new
@@ -185,39 +242,48 @@ def convert_mtot_mni(params):
 
     for par in ["mni", "mtot", "mrp"]:
         if par not in params:
-            params[par] = 10**params[f"log10_{par}"]
+            params[par] = 10 ** params[f"log10_{par}"]
 
     params["mni_c"] = params["mni"] / params["mtot"]
-    params["mrp_c"] = (params["xmix"]*(params["mtot"]-params["mni"])-params["mrp"])
+    params["mrp_c"] = params["xmix"] * (params["mtot"] - params["mni"]) - params["mrp"]
     return params
 
-############################## pulsar timing conversions ####################################
+
+# =================== pulsar timing conversions ===================
 def binary_mass_function(m_obs, m_comp, sin_i):
-    return (m_comp * sin_i)**3 / (m_obs + m_comp)**2
+    return (m_comp * sin_i) ** 3 / (m_obs + m_comp) ** 2
+
 
 def shapiro_delay(m_comp, sin_i):
     "see https://arxiv.org/pdf/1007.0933.pdf"
-    shapiro_range = msun_s*1.e6 * m_comp # in microseconds
-    orthometric_ratio = sin_i/(1+np.sqrt(1-sin_i**2))
+    shapiro_range = msun_s * 1.0e6 * m_comp  # in microseconds
+    orthometric_ratio = sin_i / (1 + np.sqrt(1 - sin_i**2))
     return shapiro_range * orthometric_ratio**3
 
+
 def einstein_delay_orbital_factor(orbital_period, eccentricity):
-    "see, e.g., 10.1007/978-3-662-62110-3_1, p.12 "
-    return msun_s**(2/3) * eccentricity * (orbital_period /2/np.pi)**(1/3)
+    "see, e.g., 10.1007/978-3-662-62110-3_1, p.12"
+    return msun_s ** (2 / 3) * eccentricity * (orbital_period / 2 / np.pi) ** (1 / 3)
+
+
 def simplified_einstein_delay(m_psr, m_comp, einstein_factor):
-    "see, e.g., 10.1007/978-3-662-62110-3_1, p.12 "
-    return einstein_factor *m_comp * (m_psr + 2*m_comp) / (m_psr + m_comp)**(4/3)
+    "see, e.g., 10.1007/978-3-662-62110-3_1, p.12"
+    return einstein_factor * m_comp * (m_psr + 2 * m_comp) / (m_psr + m_comp) ** (4 / 3)
+
 
 def einstein_delay(m_psr, m_comp, orbital_period, eccentricity):
-    "see, e.g., 10.1007/978-3-662-62110-3_1, p.12 "
+    "see, e.g., 10.1007/978-3-662-62110-3_1, p.12"
     einstein_delay_factor = einstein_delay_orbital_factor(orbital_period, eccentricity)
     return simplified_einstein_delay(m_psr, m_comp, einstein_delay_factor)
 
+
 def mass_parameters_to_sini(total_mass, mass_function, m_comp):
     "Invert the binary mass function to get sin(i) for a given total mass and mass function"
-    return np.cbrt(mass_function * total_mass**2)/m_comp
+    return np.cbrt(mass_function * total_mass**2) / m_comp
 
-############################## EOS-related conversions ####################################
+
+# =================== EOS-related conversions ===================
+
 
 def EOS_to_ns_parameters(radii, masses, lambdas):
     TOV_mass = masses.max(axis=-1)
@@ -226,27 +292,39 @@ def EOS_to_ns_parameters(radii, masses, lambdas):
 
     return TOV_mass, TOV_radius, R_14, R_16
 
+
 def EOS_to_system_parameters(radii, masses, lambdas, m1_source, m2_source):
-    (log_lambda_1, log_lambda_2) = np.interp(x=[m1_source, m2_source],
-            xp= masses, fp=np.log(lambdas), left=-np.inf, right=-np.inf)
+    (log_lambda_1, log_lambda_2) = np.interp(
+        x=[m1_source, m2_source],
+        xp=masses,
+        fp=np.log(lambdas),
+        left=-np.inf,
+        right=-np.inf,
+    )
     lambda_1 = np.exp(log_lambda_1)
     lambda_2 = np.exp(log_lambda_2)
-    (radius_1, radius_2) = np.interp( x=[m1_source, m2_source],
-            xp=masses, fp= radii, left =0, right=0)
+    (radius_1, radius_2) = np.interp(
+        x=[m1_source, m2_source], xp=masses, fp=radii, left=0, right=0
+    )
 
     return lambda_1, lambda_2, radius_1, radius_2
 
+
 def radii_from_qur(parameters):
     mass_1_source = parameters["mass_1_source"]
-    mass_2_source = parameters["mass_2_source"]    
+    mass_2_source = parameters["mass_2_source"]
     lambda_1 = parameters["lambda_1"]
     lambda_2 = parameters["lambda_2"]
 
     compactness_1 = lambda_to_compactness(lambda_1)
-    parameters["radius_1"] = mass_and_compactness_to_radius(mass_1_source, compactness_1)
-    
+    parameters["radius_1"] = mass_and_compactness_to_radius(
+        mass_1_source, compactness_1
+    )
+
     compactness_2 = lambda_to_compactness(lambda_2)
-    parameters["radius_2"] = mass_and_compactness_to_radius(mass_2_source, compactness_2)
+    parameters["radius_2"] = mass_and_compactness_to_radius(
+        mass_2_source, compactness_2
+    )
 
     chirp_mass_source = component_masses_to_chirp_mass(mass_1_source, mass_2_source)
     lambda_tilde = lambda_1_lambda_2_to_lambda_tilde(
@@ -254,90 +332,102 @@ def radii_from_qur(parameters):
     )
 
     parameters["R_16"] = (
-        chirp_mass_source
-        * np.power(lambda_tilde / 0.0042, 1.0 / 6.0)
-        * geom_msun_km
+        chirp_mass_source * np.power(lambda_tilde / 0.0042, 1.0 / 6.0) * geom_msun_km
     )
     return parameters
 
+
 def lambda_to_compactness(lambda_i):
     "Function to link tidal deformability to compactness based on quasi-universal relation"
-    loglam= np.log(lambda_i)
+    loglam = np.log(lambda_i)
     return 0.371 - 0.0391 * loglam + 0.001056 * loglam * loglam
 
+
 def mass_and_compactness_to_radius(mass, comp):
-    ### returns 0 if compactness is greater than 0.5, i.e. black hole
-    return np.where(comp<0.5, mass / comp * geom_msun_km, 0.0)
+    # returns 0 if compactness is greater than 0.5, i.e. black hole
+    return np.where(comp < 0.5, mass / comp * geom_msun_km, 0.0)
 
-############################## GRB-related conversions ####################################
 
-def gaussian_jet_energy_to_central_isotropic_energy_equivalent(Ejet, thetaCore, alphaWing):
+# =================== GRB-related conversions ===================
+
+
+def gaussian_jet_energy_to_central_isotropic_energy_equivalent(
+    Ejet, thetaCore, alphaWing
+):
     """
-    Takes the total energy of a gaussian jet as well as the angular parameters and returns the isotropic-energy equivalent 
+    Takes the total energy of a gaussian jet as well as the angular parameters and returns the isotropic-energy equivalent
     on axis. This means it is assumed that the true jet energy follows some angular structure dEjet / dOmega = epsilon_c * exp(-1/2 theta^2/thetac^2).
     Then the distribution of the isotropic energy equivalent is simply related according to E_iso(theta) = 4pi dEjet / dOmega.
-    
+
     :param Ejet: Total jet energy in ergs
     :param thetaCore: Core angle in rad
     :param alphaWing: Ratio of the wing angle and core angle.
     """
-    
-    # this is the analytical expression for int_{0}^{alphaWing*thetaCore} sin(x) *exp(-1/2 (x/thetac)^2) dx
-    prefactor = np.sqrt(np.pi) * 1.j*thetaCore *np.exp(-thetaCore**2/2) / 2**1.5
-    first_term = erf(0.5*(np.sqrt(2)*1.j*thetaCore + np.sqrt(2)*alphaWing))
-    second_term = erf(0.5*(np.sqrt(2)*1.j*thetaCore - np.sqrt(2)*alphaWing))
-    third_term = 2*erf(1.j*thetaCore/np.sqrt(2))
-    integral_factor = prefactor * (first_term + second_term - third_term)
-    integral_factor = integral_factor.real # this imaginary part is always 0 in this expression
 
-    epsilon_c = Ejet / (2*np.pi* integral_factor)
-    Eiso_c = 4*np.pi*epsilon_c
+    # this is the analytical expression for int_{0}^{alphaWing*thetaCore} sin(x) *exp(-1/2 (x/thetac)^2) dx
+    prefactor = (
+        np.sqrt(np.pi) * 1.0j * thetaCore * np.exp(-(thetaCore**2) / 2) / 2**1.5
+    )
+    first_term = erf(0.5 * (np.sqrt(2) * 1.0j * thetaCore + np.sqrt(2) * alphaWing))
+    second_term = erf(0.5 * (np.sqrt(2) * 1.0j * thetaCore - np.sqrt(2) * alphaWing))
+    third_term = 2 * erf(1.0j * thetaCore / np.sqrt(2))
+    integral_factor = prefactor * (first_term + second_term - third_term)
+    integral_factor = (
+        integral_factor.real
+    )  # this imaginary part is always 0 in this expression
+
+    epsilon_c = Ejet / (2 * np.pi * integral_factor)
+    Eiso_c = 4 * np.pi * epsilon_c
 
     return Eiso_c
 
-def powerlaw_jet_energy_to_central_isotropic_energy_equivalent(Ejet, thetaCore, alphaWing, b):
+
+def powerlaw_jet_energy_to_central_isotropic_energy_equivalent(
+    Ejet, thetaCore, alphaWing, b
+):
     """
-    Takes the total energy of a powerlaw jet as well as the angular parameters and returns the isotropic-energy equivalent 
+    Takes the total energy of a powerlaw jet as well as the angular parameters and returns the isotropic-energy equivalent
     on axis. This means it is assumed that the true jet energy follows some angular structure dEjet / dOmega = epsilon_c * (1+1/b * (theta/thetaCore)^2)^(-b/2).
     Then the distribution of the isotropic energy equivalent is simply related according to E_iso(theta) = 4pi dEjet / dOmega.
-    
+
     :param Ejet: Total jet energy in ergs
     :param thetaCore: Core angle in rad
     :param alphaWing: Ratio of the wing angle and core angle.
     :param b: Power law tail of the jet.
     """
-    x = np.linspace(0, alphaWing*thetaCore, 100)
-    y = np.sin(x)*(1+1/b*(x/thetaCore)**2)**(-b/2)
+    x = np.linspace(0, alphaWing * thetaCore, 100)
+    y = np.sin(x) * (1 + 1 / b * (x / thetaCore) ** 2) ** (-b / 2)
     integral_factor = simpson(x=x, y=y)
 
-    epsilon_c = Ejet / (2*np.pi* integral_factor)
-    Eiso_c = 4*np.pi*epsilon_c
+    epsilon_c = Ejet / (2 * np.pi * integral_factor)
+    Eiso_c = 4 * np.pi * epsilon_c
 
     return Eiso_c
-        
+
+
 class EjectaFitting:
-    mass_fitting_keys =["log10_mej_dyn", "log10_mej_wind", "log10_mej", "log10_E0"]
-    
+    mass_fitting_keys = ["log10_mej_dyn", "log10_mej_wind", "log10_mej", "log10_E0"]
+
     def __call__(self, parameters):
         conv_parameters = self.ejecta_parameter_conversion(parameters)
-        for key, val in zip(self.mass_fitting_keys,
-                conv_parameters):
+        for key, val in zip(self.mass_fitting_keys, conv_parameters):
             # We always prefer explicitly sampled ejecta parameters
             parameters[key] = parameters.get(key, val)
         return parameters
-    
+
     def ejecta_parameter_conversion(self, parameters):
-        return [ -np.inf for _ in self.mass_fitting_keys ]
+        return [-np.inf for _ in self.mass_fitting_keys]
+
 
 class NSBHEjectaFitting(EjectaFitting):
     def chibh2risco(self, chi_bh):
         """see, e.g., https://arxiv.org/pdf/2011.08948.pdf, eq. 2-4.
-        This expression gives the innermost stable circular orbit (ISCO) in units of the black hole mass as a function of the dimensionless spin parameter chi_bh. 
+        This expression gives the innermost stable circular orbit (ISCO) in units of the black hole mass as a function of the dimensionless spin parameter chi_bh.
         """
-        Z1 = 1.0 + (1.0 - chi_bh ** 2) ** (1.0 / 3) * (
+        Z1 = 1.0 + (1.0 - chi_bh**2) ** (1.0 / 3) * (
             (1 + chi_bh) ** (1.0 / 3) + (1 - chi_bh) ** (1.0 / 3)
         )
-        Z2 = np.sqrt(3.0 * chi_bh ** 2 + Z1 ** 2.0)
+        Z2 = np.sqrt(3.0 * chi_bh**2 + Z1**2.0)
 
         return 3.0 + Z2 - np.sign(chi_bh) * np.sqrt((3.0 - Z1) * (3.0 + Z1 + 2.0 * Z2))
 
@@ -359,12 +449,12 @@ class NSBHEjectaFitting(EjectaFitting):
         c=0.25512517,
         d=0.761250847,
     ):
-        '''
+        """
         equation (4) in https://arxiv.org/pdf/1807.00011
-        '''
+        """
 
-        mass_ratio = mass_2_source /mass_1_source
-        symm_mass_ratio = mass_ratio / (1.0 + mass_ratio)**2
+        mass_ratio = mass_2_source / mass_1_source
+        symm_mass_ratio = mass_ratio / (1.0 + mass_ratio) ** 2
 
         #  use the BH spin to find the normalized risco
         risco = self.chibh2risco(chi_bh)
@@ -400,17 +490,13 @@ class NSBHEjectaFitting(EjectaFitting):
         equation (9) in https://arxiv.org/abs/2002.07728
         """
 
-        mass_ratio= mass_2_source / mass_1_source
+        mass_ratio = mass_2_source / mass_1_source
 
         #  use the BH spin to find the normalized risco
         risco = self.chibh2risco(chi_bh)
         baryon_mass_2 = self.baryon_mass_NS(mass_2_source, compactness_2)
 
-        mdyn = (
-            a1 * mass_ratio**n1
-            * (1.0 - 2.0 * compactness_2)
-            / compactness_2
-        )
+        mdyn = a1 * mass_ratio**n1 * (1.0 - 2.0 * compactness_2) / compactness_2
         mdyn += -a2 * mass_ratio**n2 * risco + a4
         mdyn *= baryon_mass_2
 
@@ -428,9 +514,10 @@ class NSBHEjectaFitting(EjectaFitting):
         try:
             chi_1 = converted_parameters["chi_1"]
         except KeyError:
-            cos_tilt_1 = converted_parameters.get("cos_tilt_1", np.cos(converted_parameters["tilt_1"]))
+            cos_tilt_1 = converted_parameters.get(
+                "cos_tilt_1", np.cos(converted_parameters["tilt_1"])
+            )
             chi_1 = converted_parameters["a_1"] * cos_tilt_1
-
 
         mdyn_fit = self.dynamic_mass_fitting(
             mass_1_source, mass_2_source, compactness_2, chi_1
@@ -439,20 +526,22 @@ class NSBHEjectaFitting(EjectaFitting):
             mass_1_source, mass_2_source, compactness_2, chi_1
         )
         mdisk_fit = remnant_disk_fit - mdyn_fit
-        mej_dyn = mdyn_fit + converted_parameters['alpha']
+        mej_dyn = mdyn_fit + converted_parameters["alpha"]
 
         # prevent the output message from being flooded by these warning messages
         old = np.seterr()
-        np.seterr(invalid='ignore')
-        np.seterr(divide='ignore')
+        np.seterr(invalid="ignore")
+        np.seterr(divide="ignore")
 
         log_mej_wind = np.full_like(mdisk_fit, -np.inf)
-        log_mej_dyn  = np.full_like(mdisk_fit, -np.inf)
-        disk_mask = mdisk_fit > 0.
+        log_mej_dyn = np.full_like(mdisk_fit, -np.inf)
+        disk_mask = mdisk_fit > 0.0
 
         log_mej_dyn[disk_mask] = np.log10(mej_dyn[disk_mask])
-        log_mej_wind[disk_mask] = np.log10(mdisk_fit[disk_mask]) + np.log10(converted_parameters["ratio_zeta"])[disk_mask]
-        
+        log_mej_wind[disk_mask] = (
+            np.log10(mdisk_fit[disk_mask])
+            + np.log10(converted_parameters["ratio_zeta"])[disk_mask]
+        )
 
         total_ejeta_mass = 10**log_mej_dyn + 10**log_mej_wind
 
@@ -460,10 +549,13 @@ class NSBHEjectaFitting(EjectaFitting):
         # FIXME: NSBH might produce a GRB, too. Why not provide the same expression for BNS?
 
         np.seterr(**old)
-        return np.stack((log_mej_dyn, log_mej_wind, log10_mej, np.full_like(log_mej_wind, -np.inf)))
-    
+        return np.stack(
+            (log_mej_dyn, log_mej_wind, log10_mej, np.full_like(log_mej_wind, -np.inf))
+        )
+
     def ejecta_parameter_conversion(self, parameters):
         return self.nsbh_parameter_conversion(parameters)
+
 
 class BNSEjectaFitting(EjectaFitting):
     def log10_disk_mass_fitting(
@@ -557,103 +649,85 @@ class BNSEjectaFitting(EjectaFitting):
         return mdyn
 
     def dynamic_vel_fitting_Radice2018(
-            self,
-            mass_1,
-            mass_2,
-            compactness_1,
-            compactness_2,
-            a=-0.287,
-            b=0.494,
-            c=-3.000
+        self, mass_1, mass_2, compactness_1, compactness_2, a=-0.287, b=0.494, c=-3.000
     ):
         """
         See https://arxiv.org/pdf/1809.11161 Eq. (22)
         """
 
-        vej_dyn = a* mass_1/mass_2 * (1+c *compactness_1)
-        vej_dyn += a* mass_2/mass_1 * (1+c* compactness_2)
+        vej_dyn = a * mass_1 / mass_2 * (1 + c * compactness_1)
+        vej_dyn += a * mass_2 / mass_1 * (1 + c * compactness_2)
         vej_dyn += b
 
         return vej_dyn
-    
+
     def dynamic_mass_fitting_prompt_collapse(
-            self,
-            mass_1,
-            mass_2,
-            lambda_1,
-            lambda_2,
-            a=1.25e-4,
-            b=9.82e-1,
-            c=-2.44,
+        self,
+        mass_1,
+        mass_2,
+        lambda_1,
+        lambda_2,
+        a=1.25e-4,
+        b=9.82e-1,
+        c=-2.44,
     ):
         """
         See https://arxiv.org/pdf/2411.02342, Eq. (9)
         """
         q = mass_2 / mass_1
-        lambda_tilde = lambda_1_lambda_2_to_lambda_tilde(lambda_1, lambda_2, mass_1, mass_2)
-        mdyn = a*lambda_tilde*(q**(-1) -b) * np.exp(c/q) # this is always positive
+        lambda_tilde = lambda_1_lambda_2_to_lambda_tilde(
+            lambda_1, lambda_2, mass_1, mass_2
+        )
+        mdyn = (
+            a * lambda_tilde * (q ** (-1) - b) * np.exp(c / q)
+        )  # this is always positive
 
         return mdyn
-    
+
     def dynamic_vel_fitting_prompt_collapse(
-            self,
-            mass_1,
-            mass_2,
-            compactness_1,
-            compactness_2,
-            a=-0.395,
-            b=0.798,
-            c=-1.627):
+        self, mass_1, mass_2, compactness_1, compactness_2, a=-0.395, b=0.798, c=-1.627
+    ):
         """
         See https://arxiv.org/pdf/2411.02342, Eq. (10)
-        """        
-        vdyn = a * mass_1/mass_2 *(1 + c*compactness_1)
-        vdyn += a * mass_2/mass_1 * (1 + c* compactness_2)
+        """
+        vdyn = a * mass_1 / mass_2 * (1 + c * compactness_1)
+        vdyn += a * mass_2 / mass_1 * (1 + c * compactness_2)
         vdyn += b
 
         return vdyn
-    
+
     def log10_disk_mass_fitting_prompt_collapse(
-            self,
-            mass_1,
-            mass_2,
-            lambda_1,
-            lambda_2,
-            a=7.70,
-            b=-13.4,
-            c=8.16e-3):
+        self, mass_1, mass_2, lambda_1, lambda_2, a=7.70, b=-13.4, c=8.16e-3
+    ):
         """
         See https://arxiv.org/pdf/2411.02342, Eq. (11)
         Typo for b, b=-13.4 confirmed through author correspondence
         """
         q = mass_2 / mass_1
-        lambda_tilde = lambda_1_lambda_2_to_lambda_tilde(lambda_1, lambda_2, mass_1, mass_2)
+        lambda_tilde = lambda_1_lambda_2_to_lambda_tilde(
+            lambda_1, lambda_2, mass_1, mass_2
+        )
         log10_mdisk = a + b * q + c * lambda_tilde * q**2
 
         log10_mdisk = np.minimum(log10_mdisk, -1)
 
         return log10_mdisk
-    
+
     def chiBH_fitting(
-            self,
-            mass_1,
-            mass_2,
-            lambda_1,
-            lambda_2,
-            a = 0.537,
-            b = -0.185,
-            c = -0.514
+        self, mass_1, mass_2, lambda_1, lambda_2, a=0.537, b=-0.185, c=-0.514
     ):
         """
         See https://arxiv.org/pdf/1812.04803, Eq. (D7)
         nu needs to be divided by 0.25 and lambda_tilde by 400, confirmed through author correspondence
         """
 
-        lambda_tilde = lambda_1_lambda_2_to_lambda_tilde(lambda_1, lambda_2, mass_1, mass_2)
+        lambda_tilde = lambda_1_lambda_2_to_lambda_tilde(
+            lambda_1, lambda_2, mass_1, mass_2
+        )
         M = mass_1 + mass_2
         nu = component_masses_to_symmetric_mass_ratio(mass_1, mass_2)
-        
-        chi_BH = np.tanh(a*(nu/0.25)**2*(M+b*lambda_tilde / 400)+ c)
+
+        chi_BH = np.tanh(a * (nu / 0.25) ** 2 * (M + b * lambda_tilde / 400) + c)
 
         return chi_BH
 
@@ -661,8 +735,8 @@ class BNSEjectaFitting(EjectaFitting):
 
         # prevent the output message flooded by these warning messages
         old = np.seterr()
-        np.seterr(invalid='ignore')
-        np.seterr(divide='ignore')
+        np.seterr(invalid="ignore")
+        np.seterr(divide="ignore")
 
         mass_1_source = converted_parameters["mass_1_source"]
         mass_2_source = converted_parameters["mass_2_source"]
@@ -675,7 +749,7 @@ class BNSEjectaFitting(EjectaFitting):
 
         compactness_1 = mass_1_source * geom_msun_km / radius_1
         compactness_2 = mass_2_source * geom_msun_km / radius_2
-        #FIXME: switch to prompt collapse fitting for appropriate thresholds
+        # FIXME: switch to prompt collapse fitting for appropriate thresholds
         mdyn_fit = self.dynamic_mass_fitting_KrFo(
             mass_1_source, mass_2_source, compactness_1, compactness_2
         )
@@ -690,12 +764,31 @@ class BNSEjectaFitting(EjectaFitting):
         log10_mej_dyn = np.log10(mdyn_fit + converted_parameters["alpha"])
 
         log10_mej_wind = np.log10(converted_parameters["ratio_zeta"]) + log10_mdisk_fit
+
+        # FIXME Weizmann: dynamic_mass_fitting_KrFo/log10_disk_mass_fitting
+        # clip negative fit values via np.maximum(0, .), which silently turns
+        # a -inf signal (radius<=0 -> compactness=inf, i.e. not a real NS)
+        # into a plain finite 0.0 before np.isfinite() downstream can catch
+        # it. Force -inf explicitly here, before that clipping had a chance
+        # to hide it, whenever either component isn't a real NS under this
+        # EOS (mirrors the old compactness == 0.5 check from nmma 0.2.3,
+        # without relying on radius_1/radius_2 being an actual Schwarzschild
+        # radius rather than the 0 sentinel used here).
+        not_ns = (radius_1 <= 0) | (radius_2 <= 0)
+        log10_mej_dyn = np.where(not_ns, -np.inf, log10_mej_dyn)
+        log10_mej_wind = np.where(not_ns, -np.inf, log10_mej_wind)
+
         # total eject mass
         total_ejeta_mass = 10**log10_mej_dyn + 10**log10_mej_wind
+        # FIXME Weizmann: np.seterr(**old) used to run before this log10
+        # call, so log10(0) (from a -inf/-inf pair, e.g. once not_ns forces
+        # both to -inf) raised an unsuppressed RuntimeWarning: divide by
+        # zero. Compute log10_mej_total first, restore seterr after.
+        log10_mej_total = np.log10(total_ejeta_mass)
 
         np.seterr(**old)
-        return log10_mej_dyn, log10_mej_wind, np.log10(total_ejeta_mass), log10_mdisk_fit
-    
+        return log10_mej_dyn, log10_mej_wind, log10_mej_total, log10_mdisk_fit
+
     def grb_energy_conversion(self, converted_parameters, log10_mdisk_fit):
 
         # GRB afterglow energy
@@ -703,72 +796,104 @@ class BNSEjectaFitting(EjectaFitting):
         log10_Ejet += np.log10(1.0 - converted_parameters["ratio_zeta"])
         log10_Ejet += log10_mdisk_fit + np.log10(msun_to_ergs)
 
-        thetaCore = converted_parameters.get("thetaCore", 0.105) ## default about 6 degree, see arxiv:2210.05695
-        
-        if not any(key in converted_parameters for key in ["thetaWing", "alphaWing", "b"]):
-            return log10_Ejet - np.log10(np.sin(thetaCore/2)**2)
+        thetaCore = converted_parameters.get(
+            "thetaCore", 0.105
+        )  # default about 6 degree, see arxiv:2210.05695
+
+        if not any(
+            key in converted_parameters for key in ["thetaWing", "alphaWing", "b"]
+        ):
+            return log10_Ejet - np.log10(np.sin(thetaCore / 2) ** 2)
 
         if "alphaWing" in converted_parameters:
-            alphaWing = converted_parameters['alphaWing'] 
+            alphaWing = converted_parameters["alphaWing"]
         else:
-            alphaWing = converted_parameters["thetaWing"] / converted_parameters["thetaCore"]
+            alphaWing = (
+                converted_parameters["thetaWing"] / converted_parameters["thetaCore"]
+            )
 
-        
-        if "b" in converted_parameters: # power law jet
+        if "b" in converted_parameters:  # power law jet
             jet_func = powerlaw_jet_energy_to_central_isotropic_energy_equivalent
-            data = np.column_stack((10**log10_Ejet, thetaCore, alphaWing, converted_parameters["b"]))
-            
+            data = np.column_stack(
+                (10**log10_Ejet, thetaCore, alphaWing, converted_parameters["b"])
+            )
+
         else:
             jet_func = gaussian_jet_energy_to_central_isotropic_energy_equivalent
             data = np.column_stack((10**log10_Ejet, thetaCore, alphaWing))
-                
+
         out = np.log10([jet_func(*row) for row in data])
-        return np.squeeze(out)    
-        
+        return np.squeeze(out)
 
     def bns_parameter_conversion(self, parameters):
-        log10_mej_dyn, log10_mej_wind, log10_mej_total, log10_mdisk_fit = self.bns_ejecta_conversion(parameters)
+        (
+            log10_mej_dyn,
+            log10_mej_wind,
+            log10_mej_total,
+            log10_mdisk_fit,
+        ) = self.bns_ejecta_conversion(parameters)
 
         if "log10_E0" in parameters:
             log10_E0 = parameters["log10_E0"]
         else:
             log10_E0 = self.grb_energy_conversion(parameters, log10_mdisk_fit)
-        
+
         converted_ejecta = (log10_mej_dyn, log10_mej_wind, log10_mej_total, log10_E0)
 
-        return  np.where(np.isfinite(converted_ejecta), converted_ejecta, -np.inf)
+        return np.where(np.isfinite(converted_ejecta), converted_ejecta, -np.inf)
 
     def ejecta_parameter_conversion(self, parameters):
         return self.bns_parameter_conversion(parameters)
 
+
 class KilonovaEjectaFitting(BNSEjectaFitting, NSBHEjectaFitting):
     def ejecta_parameter_conversion(self, parameters):
+        # FIXME Weizmann: routing used to check radius_1>0 alone for BNS,
+        # not radius_2>0 too. mass_1 >= mass_2 by convention, so in the
+        # common case radius_1>0 already implies radius_2>0 (a lighter mass
+        # is inside the EOS's mass range whenever a heavier one is), but
+        # not always: mass_2 can fall below the EOS table's tabulated
+        # minimum mass even while mass_1 is a valid NS mass. That row was
+        # still routed to bns_parameter_conversion, which computed
+        # compactness_2 = mass_2*geom_msun_km/radius_2 = inf (radius_2==0),
+        # and that inf got silently clipped to a finite mej by
+        # np.maximum(0, .) inside the mass-fitting formulas before
+        # np.isfinite() downstream had any chance to catch it, a
+        # physically wrong, finite ejecta mass got published for a system
+        # that isn't actually a BNS under this EOS. Requiring radius_2>0
+        # too keeps bns_parameter_conversion from ever seeing that case;
+        # it now correctly falls through to nsbh/BBH instead.
         try:
-            #heavier object is a NS
-            if parameters['radius_1'] > 0.:
+            # both objects are NS
+            if (parameters["radius_1"] > 0.0) and (parameters["radius_2"] > 0.0):
                 return self.bns_parameter_conversion(parameters)
             # heavier object is BH, but lighter object is NS
-            elif parameters['radius_2']>0.:
+            elif parameters["radius_2"] > 0.0:
                 return self.nsbh_parameter_conversion(parameters)
-            # both objects are BHs
+            # both objects are BHs (or lighter mass is below the EOS's
+            # tabulated range)
             else:
                 return np.full(4, -np.inf)
         except ValueError:
-            #ValueError occurs when trying to obtain truth values of arrays 
+            # ValueError occurs when trying to obtain truth values of arrays
             # -> evaluate many points at once and chose conditional ejecta_fitting
-            return  np.where(parameters["radius_1"]>0.,  #heavier object is a NS
-                        self.bns_parameter_conversion(parameters),
-                    np.where(parameters["radius_2"]>0., ## elif component 2 is a NS
-                        self.nsbh_parameter_conversion(parameters),
-                    ### else assume BBH (i.e., no ejecta)
-                        np.full((4,)+ parameters["mass_1_source"].shape, -np.inf)
-                        )
-                    )
-              
+            is_bns = (parameters["radius_1"] > 0.0) & (parameters["radius_2"] > 0.0)
+            return np.where(
+                is_bns,  # both objects are NS
+                self.bns_parameter_conversion(parameters),
+                np.where(
+                    parameters["radius_2"] > 0.0,  # elif component 2 is a NS
+                    self.nsbh_parameter_conversion(parameters),
+                    # else assume BBH (i.e., no ejecta)
+                    np.full((4,) + parameters["mass_1_source"].shape, -np.inf),
+                ),
+            )
+
+
 class MultimessengerConversion:
     def __init__(self, *conversions):
         self._conversions = conversions
-    
+
     @classmethod
     def from_args(cls, args):
         # FIXME: implement argument parsing to select conversions
@@ -779,110 +904,115 @@ class MultimessengerConversion:
         conversions = []
 
         # NOTE: Order matters!!!
-        if 'cosmo' in instruction_dict:
-            set_cosmology(instruction_dict['cosmo'])
-            conversions.append(cosmology_to_distance) 
+        if "cosmo" in instruction_dict:
+            set_cosmology(instruction_dict["cosmo"])
+            conversions.append(cosmology_to_distance)
 
-        if 'gw' in instruction_dict:
-            conversions.append(instruction_dict['gw'])
+        if "gw" in instruction_dict:
+            conversions.append(instruction_dict["gw"])
 
-        if 'eos' in instruction_dict:
-            conversions.append(instruction_dict['eos'])
+        if "eos" in instruction_dict:
+            conversions.append(instruction_dict["eos"])
 
-        if 'ejecta' in instruction_dict:    
+        if "ejecta" in instruction_dict:
             conversions.append(KilonovaEjectaFitting())
 
-        if 'em' in instruction_dict:
-            conversions.append(instruction_dict['em'])
-        
-        if 'custom' in instruction_dict:
-            conversions.append(instruction_dict['custom'])
+        if "em" in instruction_dict:
+            conversions.append(instruction_dict["em"])
+
+        if "custom" in instruction_dict:
+            conversions.append(instruction_dict["custom"])
 
         return cls(*conversions)
-    
+
     @classmethod
     def basic_cbc(cls, eos_conversion, em_conversion):
-        return cls(bbh_source_frame, eos_conversion, KilonovaEjectaFitting(), em_conversion)
-    
+        return cls(
+            bbh_source_frame, eos_conversion, KilonovaEjectaFitting(), em_conversion
+        )
+
     def convert_to_multimessenger_parameters(self, parameters, add_new_keys=False):
         original_keys = list(parameters.keys())
         converted_parameters = {k: val_to_scalar(v) for k, v in parameters.items()}
 
         converted_parameters = self.core_conversion(converted_parameters)
 
-        converted_parameters = {k: val_to_scalar(v) for k, v in converted_parameters.items()}
-        
+        converted_parameters = {
+            k: val_to_scalar(v) for k, v in converted_parameters.items()
+        }
+
         if add_new_keys:
-            added_keys = [k for k in converted_parameters.keys() if k not in original_keys]
+            added_keys = [
+                k for k in converted_parameters.keys() if k not in original_keys
+            ]
             return converted_parameters, added_keys
         else:
             return converted_parameters
-    
+
     def core_conversion(self, parameters):
         for conv in self._conversions:
             parameters = conv(parameters)
         return parameters
-    
+
     def identity_conversion(self, parameters):
         return parameters
 
-        
-        
+
 label_mapping = {
-    ## Cosmology parameters ##
-    'Hubble_constant'       : r'$H_0{\rm\,[km\,s^{-1}\,Mpc^{-1}]}$',
-    'Omega_matter'          : r'$\Omega_{m}$',
-    'redshift'              : r'$z$',
-    ## System parameters ##
-    'inclination_EM'        : r'$\theta_{obs}$',
-    'theta_jn'              : r'$\theta_{JN}$',
-    'cos_theta_jn'          : r'$\cos{\theta_{JN}}$',
-    'luminosity_distance'   : r'$d_L\,{\rm [Mpc]}$', 
-    ## GW parameters ##
-    'chirp_mass'            :r'$\mathcal{M}_c\,{\rm [M_{\odot}]}$',
-    'mass_ratio'            : r'$q$', 
-    'chi_eff'               : r'$\chi_{\rm{eff}}$', 
-    'mass_1_source'         : r'$m_{1,s}\,{\rm [M_{\odot}]}$', 
-    'mass_2_source'         : r'$m_{2,s}\,{\rm [M_{\odot}]}$', 
-    ## KN parameters ##
-    'log10_mej'             : r'$\log_{10}(M_{\rm{ej}}\,{\rm [M_{\odot}]})$',
-    'log10_mej_dyn'         : r'$\log_{10}(M_{\rm{dyn}}\,{\rm [M_{\odot}]})$',
-    'log10_mej_wind'        : r'$\log_{10}(M_{\rm{wind}}\,{\rm [M_{\odot}]})$',
-    'ratio_zeta'            : r'$\zeta$',
-    'alpha'                 : r'$\alpha$',
-    'KNtheta'               : r'$\theta_{\rm obs}\,[^\circ]$',
-    'KNphi'                 : r'$\phi_{KN}\,[^\circ]$',
-    # Bu parameters ##
-    'vej_dyn'               : r'$v_{\rm{dyn}}\,{\rm [c]}$',
-    'vej_wind'              : r'$v_{\rm{wind}}\,{\rm [c]}$',
-    'v_ej_dyn'              : r'$v_{\rm{dyn}}\,{\rm [c]}$',
-    'v_ej_wind'             : r'$v_{\rm{wind}}\,{\rm [c]}$',
-    'Ye_dyn'                : r'$Y_{e,{\rm{dyn}}}$',
-    'kappa_Ye'              : r'$\kappa_{\rm{Y_e}}$',
-    'kappa_v'               : r'$\kappa_{v}$', 
-    ## GRB parameters ##
-    'log10_E0'              : r'$\log_{10}(E_{\rm iso,0}\,{\rm [erg]})$',
-    'ratio_epsilon'         : r'$\epsilon$',
-    'thetaCore'             : r'$\theta_{c}$',
-    'thetaWing'             : r'$\theta_{w}$',
-    'alphaWing'             : r'$\alpha_{w}$',
-    'log10_n0'              : r'$\log_{10}(n_{0}\,{\rm [cm^{-3}]})$',
-    'p'                     : r'$p$',
-    'log10_epsilon_e'       : r'$\log_{10}(\epsilon_{e})$',
-    'log10_epsilon_B'       : r'$\log_{10}(\epsilon_{B})$',
-    ## Ejecta parameters ##
-    'mni'                   : r'$M_{\rm{Ni}}\,{\rm [M_{\odot}]}$',
-    'mtot'                  : r'$M_{\rm{tot}}\,{\rm [M_{\odot}]}$',
-    'mrp'                   : r'$M_{\rm{rp}}\,{\rm [M_{\odot}]}$',
-    'mni_c'                 : r'$M_{\rm{Ni}}/M_{\rm{tot}}$',
-    'mrp_c'                 : r'$M_{\rm{rp,c}}\,{\rm [M_{\odot}]}$',
-    ### EOS parameters ###
-    'L_sym'                 : r'$L_{\rm sym}\,{\rm [MeV]}$',
-    'K_sym'                 : r'$K_{\rm sym}\,{\rm [MeV]}$',
-    'K_sat'                 : r'$K_{\rm sat}\,{\rm [MeV]}$',
-    '3n_sat'                : r'$c^2_{3n_{\rm sat}}\,{\rm [c^2]}$',
-    '5n_sat'                : r'$c^2_{5n_{\rm sat}}\,{\rm [c^2]}$',
-    'TOV_mass'              : r'$M_{\rm{TOV}}\,{\rm [M_{\odot}]}$',
-    'R_14'                  : r'$R_{1.4}\,{\rm[km]}$',
-    'lambda_tilde'          : r'$\tilde{\Lambda}$', 
+    # Cosmology parameters #
+    "Hubble_constant": r"$H_0{\rm\,[km\,s^{-1}\,Mpc^{-1}]}$",
+    "Omega_matter": r"$\Omega_{m}$",
+    "redshift": r"$z$",
+    # System parameters #
+    "inclination_EM": r"$\theta_{obs}$",
+    "theta_jn": r"$\theta_{JN}$",
+    "cos_theta_jn": r"$\cos{\theta_{JN}}$",
+    "luminosity_distance": r"$d_L\,{\rm [Mpc]}$",
+    # GW parameters #
+    "chirp_mass": r"$\mathcal{M}_c\,{\rm [M_{\odot}]}$",
+    "mass_ratio": r"$q$",
+    "chi_eff": r"$\chi_{\rm{eff}}$",
+    "mass_1_source": r"$m_{1,s}\,{\rm [M_{\odot}]}$",
+    "mass_2_source": r"$m_{2,s}\,{\rm [M_{\odot}]}$",
+    # KN parameters #
+    "log10_mej": r"$\log_{10}(M_{\rm{ej}}\,{\rm [M_{\odot}]})$",
+    "log10_mej_dyn": r"$\log_{10}(M_{\rm{dyn}}\,{\rm [M_{\odot}]})$",
+    "log10_mej_wind": r"$\log_{10}(M_{\rm{wind}}\,{\rm [M_{\odot}]})$",
+    "ratio_zeta": r"$\zeta$",
+    "alpha": r"$\alpha$",
+    "KNtheta": r"$\theta_{\rm obs}\,[^\circ]$",
+    "KNphi": r"$\phi_{KN}\,[^\circ]$",
+    # Bu parameters #
+    "vej_dyn": r"$v_{\rm{dyn}}\,{\rm [c]}$",
+    "vej_wind": r"$v_{\rm{wind}}\,{\rm [c]}$",
+    "v_ej_dyn": r"$v_{\rm{dyn}}\,{\rm [c]}$",
+    "v_ej_wind": r"$v_{\rm{wind}}\,{\rm [c]}$",
+    "Ye_dyn": r"$Y_{e,{\rm{dyn}}}$",
+    "kappa_Ye": r"$\kappa_{\rm{Y_e}}$",
+    "kappa_v": r"$\kappa_{v}$",
+    # GRB parameters #
+    "log10_E0": r"$\log_{10}(E_{\rm iso,0}\,{\rm [erg]})$",
+    "ratio_epsilon": r"$\epsilon$",
+    "thetaCore": r"$\theta_{c}$",
+    "thetaWing": r"$\theta_{w}$",
+    "alphaWing": r"$\alpha_{w}$",
+    "log10_n0": r"$\log_{10}(n_{0}\,{\rm [cm^{-3}]})$",
+    "p": r"$p$",
+    "log10_epsilon_e": r"$\log_{10}(\epsilon_{e})$",
+    "log10_epsilon_B": r"$\log_{10}(\epsilon_{B})$",
+    # Ejecta parameters #
+    "mni": r"$M_{\rm{Ni}}\,{\rm [M_{\odot}]}$",
+    "mtot": r"$M_{\rm{tot}}\,{\rm [M_{\odot}]}$",
+    "mrp": r"$M_{\rm{rp}}\,{\rm [M_{\odot}]}$",
+    "mni_c": r"$M_{\rm{Ni}}/M_{\rm{tot}}$",
+    "mrp_c": r"$M_{\rm{rp,c}}\,{\rm [M_{\odot}]}$",
+    # EOS parameters #
+    "L_sym": r"$L_{\rm sym}\,{\rm [MeV]}$",
+    "K_sym": r"$K_{\rm sym}\,{\rm [MeV]}$",
+    "K_sat": r"$K_{\rm sat}\,{\rm [MeV]}$",
+    "3n_sat": r"$c^2_{3n_{\rm sat}}\,{\rm [c^2]}$",
+    "5n_sat": r"$c^2_{5n_{\rm sat}}\,{\rm [c^2]}$",
+    "TOV_mass": r"$M_{\rm{TOV}}\,{\rm [M_{\odot}]}$",
+    "R_14": r"$R_{1.4}\,{\rm[km]}$",
+    "lambda_tilde": r"$\tilde{\Lambda}$",
 }

--- a/nmma/core/gitlab.py
+++ b/nmma/core/gitlab.py
@@ -50,7 +50,13 @@ def download(file_info):
     resp = requests.get(url, stream=True)
     total = int(resp.headers.get("content-length", 0))
     chunk_size = 4096
-    file_content = b""
+    # FIXME Weizmann: this used to declare file_content = b"" and never
+    # append downloaded chunks to it, then check len(file_content) != total
+    # belown, always comparing 0 to total, so every download (even a fully
+    # successful one, correctly written to disk chunk by chunk) raised
+    # "Only 0 of N bytes were downloaded". Track the real byte count written
+    # instead.
+    downloaded = 0
 
     Path(filepath).parent.mkdir(parents=True, exist_ok=True)
     with open(filepath, "wb") as f, tqdm(
@@ -62,12 +68,13 @@ def download(file_info):
     ) as pbar:
         for chunk in resp.iter_content(chunk_size=chunk_size):
             f.write(chunk)
+            downloaded += len(chunk)
             pbar.update(len(chunk))
 
-    if len(file_content) != total:
+    if downloaded != total:
         raise ValueError(
             f"Downloaded file {filepath} is incomplete. "
-            f"Only {len(file_content)} of {total} bytes were downloaded."
+            f"Only {downloaded} of {total} bytes were downloaded."
         )
 
     return filepath
@@ -88,8 +95,15 @@ def decompress(file_path):
 
 
 def download_and_decompress(file_info):
-    download(file_info)
-    decompress(file_info[1])
+    filepath = download(file_info)
+    # FIXME Weizmann: this used to call decompress() unconditionally, but
+    # filepaths/urls are built from core_format/filter_format ("joblib" or
+    # "h5"), never "lzma" -- so downloaded files are never actually
+    # lzma-compressed, and decompress()'s own extension check would always
+    # reject them with "is not a .lzma file". Only decompress when the
+    # downloaded file is actually a .lzma archive.
+    if str(filepath).endswith(".lzma"):
+        decompress(filepath)
 
 
 def download_models_list(models_home=None):

--- a/nmma/em/lightcurve_handling.py
+++ b/nmma/em/lightcurve_handling.py
@@ -129,17 +129,22 @@ def compute_chisquare_dict(transient, model_data, model_time, model_error, verbo
                 sigma_y[finite_idx],
             )
             
-            offset = (y_det - np.interp(t_det,model_time, model_data[filt])) ** 2
+            signed_diff = y_det - np.interp(t_det,model_time, model_data[filt])
+            offset = signed_diff ** 2
             try:
                 errors = np.interp(t_det,model_time, model_error[filt])
             except ValueError:
-                errors = model_error[filt] 
+                errors = model_error[filt]
             total_unc = sigma_y_det**2 + errors**2
             chi2_per_filt = np.sum(offset / total_unc)
             # store the data
             chi2 += chi2_per_filt
             dof += n_finite
-            mismatches[filt] = (offset, total_unc)
+            # signed_diff kept alongside offset/total_unc so callers can plot
+            # a signed, normalized residual (signed_diff / sqrt(total_unc))
+            # instead of the unsigned, unnormalized `offset`, see
+            # plotting_utils.basic_em_analysis_plot.
+            mismatches[filt] = (offset, total_unc, signed_diff)
             chi2_dict[filt] = float(chi2_per_filt / n_finite)
 
             if verbose:

--- a/nmma/em/plotting_utils.py
+++ b/nmma/em/plotting_utils.py
@@ -1,5 +1,6 @@
 import matplotlib.pyplot as plt
 import matplotlib
+from matplotlib.ticker import NullFormatter
 from mpl_toolkits.axes_grid1 import make_axes_locatable
 from itertools import cycle
 import numpy as np
@@ -12,13 +13,30 @@ nmma_colors = fig_setup()
 ################# MAIN PLOTS #################
 ##############################################
 def basic_em_analysis_plot(
-        transient, plot_filters, mags_to_plot, error_dict, chi2_dict, 
+        transient, plot_filters, mags_to_plot, error_dict, chi2_dict,
         mismatches, sub_model_plot_props, xlim, ylim, save_path,
-        ncols = 2, fig = None, shared_data = True,
+        ncols = None, fig = None, shared_data = True,
         markersize = 8, **kwargs):
 
     ### setup to get quantities
     filter_names = list(plot_filters.keys())
+    if ncols is None:
+        # Dynamic column count: one row for up to 3 filters (e.g.
+        # ztfg/ztfr/ztfi); beyond that, pick whichever of {2, 3} columns
+        # leaves the fewest empty grid cells, preferring the smaller (wider
+        # panels, easier to read a light curve) on a tie. E.g. 5 or 7
+        # filters used to always get 3 columns (1-2 dead cells) even though
+        # 2 columns leaves just as few or fewer; 6 filters is a tie (both
+        # leave 0 empty), so it now picks 2 columns instead of 3.
+        n_filt = len(filter_names)
+        if n_filt <= 3:
+            ncols = n_filt
+        else:
+            ncols = min((2, 3), key=lambda c: ((-n_filt) % c, c))
+        # old fixed rule (1 row up to 3, 2 cols for 4, 3 cols beyond that):
+        # ncols = n_filt if n_filt <= 3 else (2 if n_filt == 4 else 3)
+        # old fixed default, pass ncols=2 explicitly to get this back:
+        # ncols = 2
     def_data_colours = plt.cm.plasma(np.linspace(0, 1, len(filter_names)))[::-1]
     fit_color = kwargs.pop('color', next(nmma_colors))
     marker = kwargs.pop('marker', next(marker_cycle)) 
@@ -62,21 +80,33 @@ def basic_em_analysis_plot(
         plot_bestfit_with_errors(ax_sum, time, mags_to_plot[filt], error_dict[filt], sub_model_plot_props, cnt, fit_color)
  
         ax_delta = fig.axes[cnt+n_axes]
-        
+        # sharex(ax_sum) means ax_delta inherits the log scale set in
+        # adjust_observations(), but not its formatter -- without this, log
+        # minor ticks (4x10^-1, 6x10^-1, ...) print a label at every minor
+        # tick and crowd into the major tick labels below them.
+        ax_delta.xaxis.set_minor_formatter(NullFormatter())
 
-        obs_times, obs_unc = transient.light_curve_times, transient.light_curve_uncertainties  
+        obs_times, obs_unc = transient.light_curve_times, transient.light_curve_uncertainties
         det_times = obs_times[filt][np.isfinite(obs_unc[filt])]
         
         if det_times.size>0: ## show scatter
             ax_delta = fig.axes[cnt+n_axes]
-            diff_per_data, _ = mismatches[filt]
+            offset, total_unc, signed_diff = mismatches[filt]
+            # signed, normalized residual: (data - model) / sigma_tot, in
+            # units of sigma, e.g. +2 reads as "2 sigma above the model".
+            normalized_residual = signed_diff / np.sqrt(total_unc)
 
             delta_ylim = ax_delta.get_ylim()
-            dylim = (min(delta_ylim[0], 0.9*min(diff_per_data)), 
-                    max(delta_ylim[1], 1.1*max(diff_per_data)))
+            lo, hi = np.min(normalized_residual), np.max(normalized_residual)
+            pad = 0.1 * max(hi - lo, 1e-6)
+            dylim = (min(delta_ylim[0], lo - pad),
+                    max(delta_ylim[1], hi + pad))
             ax_delta.set_ylim(dylim)
 
-            ax_delta.scatter(det_times, diff_per_data, color=fit_color, marker=marker)
+            ax_delta.scatter(det_times, normalized_residual, color=fit_color, marker=marker)
+            # old: unsigned, unnormalized residual (data - model)^2 in mag^2
+            # -- swap the two lines above/below back if this is needed again.
+            # ax_delta.scatter(det_times, offset, color=fit_color, marker=marker)
 
             if ax_sum.get_legend():
                 ax_sum.get_legend().remove()
@@ -96,9 +126,10 @@ def init_em_analysis_plot(plot_filters, ncols):
     filter_names = list(plot_filters.keys())
     fig, axes = analysis_plot_geometry(filter_names, ncols=ncols)
     fig.supylabel("AB magnitude", rotation=90)
-    fig.supxlabel("Time [days]")
+    fig.supxlabel("Time [days]", fontsize=14)
     init_limits = np.array([1000, -1000])# dummy values
-    
+    nrow = int(np.ceil(len(filter_names) / ncols))
+
     for cnt, filt in enumerate(filter_names):
         # summary plot
         row, col = divmod(cnt, ncols)
@@ -113,9 +144,20 @@ def init_em_analysis_plot(plot_filters, ncols):
                                         size='40%',
                                         sharex=ax_sum,
                                         pad=0.1)
-        # ax_delta.axhline(0, linestyle='--', color='k')
-        ax_delta.set_ylabel(r"$\Delta$ mag")
-        ax_delta.set_ylim(0,1e-9)
+        ax_delta.axhline(0, linestyle='--', color='k', linewidth=1)
+        ax_delta.set_ylabel(r"$\Delta / \sigma$")
+        ax_delta.set_ylim(-5, 5)
+        # old (unsigned, unnormalized Δmag = (data-model)^2, mag^2):
+        # ax_delta.set_ylabel(r"$\Delta$ mag")
+        # ax_delta.set_ylim(0,1e-9)
+
+        # Every row except the bottom-most one previously left ax_delta's
+        # x-tick labels visible (sharex only syncs limits/scale, not label
+        # visibility), so the log-scale minor tick labels of one row
+        # collided with the row below it into an unreadable overlap.
+        if row < nrow - 1:
+            plt.setp(ax_delta.get_xticklabels(), visible=False)
+            plt.setp(ax_delta.get_xticklabels(minor=True), visible=False)
     return fig
 
 def plot_bestfit_with_errors(ax_sum, time, mag_plot, error_budget, 
@@ -408,8 +450,13 @@ def adjust_observations(ax, transient, filt, xlim, fix_ylim):
 
     ax.set_xlim(xlim)
     # ax_delta.set_xlim(xlim)
-    if xlim[0] > 0:
-        ax.set_xscale('log')
+    # old: log-scale x-axis. On a typical ~20-day window this leaves only
+    # 1-2 major ticks visible (e.g. just "10^0"), which reads as almost no
+    # tick labels at all. Switched to linear (matches the Astro-Colibri
+    # style plot in fitting/plot_bestfit.py) for evenly-spaced ticks
+    # regardless of the time window. Re-enable by uncommenting below.
+    # if xlim[0] > 0:
+    #     ax.set_xscale('log')
     if fix_ylim:
         ax.set_ylim(fix_ylim)
     else:

--- a/nmma/joint/injection_handling.py
+++ b/nmma/joint/injection_handling.py
@@ -145,6 +145,16 @@ class NMMAInjectionCreator(InjectionCreator):
 
     def generate_injection_file(self):
         """Generate the injection file based on the provided parameters."""
+        # FIXME Weizmann: NMMAInjectionCreator overrides
+        # InjectionCreator.generate_injection_file(self, filepath, extension)
+        # with a different signature, which silently dropped the parent's
+        # bilby.core.utils.random.seed(self.generation_seed) call. Without
+        # it, self.priors.sample(n) (called from generate_prelim_dataframe)
+        # draws from bilby's unseeded internal RNG, so --generation-seed had
+        # no effect on the actual prior draws: identical commands (same
+        # seed, same prior, same --gw-injection-file) produced a different
+        # --binary-type filter count on every run.
+        bilby.core.utils.random.seed(self.generation_seed)
         dataframe = self.generate_prelim_dataframe()
         if self.include_checks:
             dataframe = self.testing_and_postprocessing(dataframe)

--- a/nmma/joint/injection_handling.py
+++ b/nmma/joint/injection_handling.py
@@ -17,6 +17,8 @@ from ..core.utils import set_filename, rejection_sample, read_injection_file
 from ..core.conversion import (
     MultimessengerConversion,
     KilonovaEjectaFitting,
+    BNSEjectaFitting,
+    NSBHEjectaFitting,
     bbh_source_frame,
 )
 from ..em import utils, lightcurve_handling as lch
@@ -56,6 +58,13 @@ class NMMAInjectionCreator(InjectionCreator):
         # bilby-pipe injection_creator can only handle dat or json
         self.extension = "dat" if args.extension == "csv" else args.extension
         self.filename = set_filename(args.injection_file, args)
+
+        # FIXME Weizmann: restores nmma 0.2.3's --binary-type/--eject
+        # behaviour -- see joint_parsing.py's --binary-type help for why
+        # this is needed alongside (not instead of) --tests/--post-processing.
+        self.binary_type_filter = getattr(args, "binary_type", None)
+        if self.binary_type_filter is not None and not getattr(args, "eos_file", None):
+            raise ValueError("--binary-type requires --eos-file")
 
         if args.simple_setup:
             self.include_checks = False
@@ -203,7 +212,15 @@ class NMMAInjectionCreator(InjectionCreator):
             dataframe = test_df
             print("All injections passed all tests immediately.")
         else:
-            dataframe["tests_passed"] = test_df["tests_passed"]
+            # FIXME Weizmann: this used to copy only the 'tests_passed'
+            # column onto the original (unconverted) dataframe, discarding
+            # every column test_wrap()/core_conversion() added (e.g.
+            # mass_1_source, lambda_1/2, radius_1/2 from eos conversion) for
+            # rows that passed on the first draw. With --original-parameters
+            # those columns are never recomputed afterwards, so they were
+            # silently missing from the final injection file whenever at
+            # least one row needed a redraw.
+            dataframe = test_df
             dataframe = self.refill_failed_tests(dataframe)
         dataframe.drop(columns=["tests_passed"], inplace=True)
 
@@ -214,7 +231,58 @@ class NMMAInjectionCreator(InjectionCreator):
         # or add expensive information not required for tests
         for postprocess in self.postprocessing:
             postprocess(dataframe)
+
+        # FIXME Weizmann: --binary-type/--eject restoration (nmma 0.2.3
+        # behaviour); see joint_parsing.py's --binary-type help. This is a
+        # one-shot filter (drop and done), never a redraw, so it works even
+        # when masses come from an external --gw-injection-file.
+        if self.binary_type_filter is not None:
+            dataframe = self.filter_by_binary_type(dataframe)
+
         return dataframe
+
+    def filter_by_binary_type(self, dataframe):
+        """Apply a single ejecta formula (BNS or NSBH) to every injection,
+        uniformly, and drop those whose resulting ejecta mass isn't finite
+        -- i.e. the assumed binary type isn't physically consistent with
+        the chosen EOS for that injection's masses. Mirrors nmma 0.2.3's
+        --eject + --binary-type BNS/NSBH:
+            index_taken = np.where(isfinite(log10_mej_dyn) * isfinite(log10_mej_wind))[0]
+            dataframe = dataframe.take(index_taken)
+        applied once, not through the --tests redraw mechanism (which
+        cannot work here: a mass read from --gw-injection-file is fixed and
+        can never be redrawn away from failing a test).
+        """
+        if self.binary_type_filter == "BNS":
+            fitter = BNSEjectaFitting()
+        elif self.binary_type_filter == "NSBH":
+            fitter = NSBHEjectaFitting()
+        else:
+            raise ValueError(f"Unknown binary type: {self.binary_type_filter}")
+
+        # FIXME Weizmann: don't call fitter(dataframe) (EjectaFitting.__call__)
+        # here -- it does parameters[key] = parameters.get(key, val), i.e.
+        # prefers an already-sampled log10_mej_dyn/log10_mej_wind (e.g. from
+        # a prior that samples them directly) over the EOS-derived value.
+        # nmma 0.2.3's --eject had no such preference: it always overwrote
+        # log10_mej_dyn/log10_mej_wind with the freshly computed value,
+        # unconditionally. --binary-type is an explicit request to recompute
+        # ejecta from this EOS + assumed type, so it must overwrite the same
+        # way, not silently no-op against a prior that happens to sample
+        # those two keys directly.
+        conv_parameters = fitter.ejecta_parameter_conversion(dataframe)
+        for key, val in zip(fitter.mass_fitting_keys, conv_parameters):
+            dataframe[key] = val
+
+        mask = np.isfinite(dataframe["log10_mej_dyn"]) & np.isfinite(
+            dataframe["log10_mej_wind"]
+        )
+        kept, total = int(mask.sum()), len(dataframe)
+        print(
+            f"--binary-type {self.binary_type_filter}: kept {kept}/{total} "
+            "injections (dropped those with non-finite ejecta mass)"
+        )
+        return dataframe[mask].reset_index(drop=True)
 
     def test_wrap(self, dataframe):
         test_df = dataframe.copy()
@@ -260,10 +328,15 @@ class NMMAInjectionCreator(InjectionCreator):
 
             dataframe.loc[fail_mask, self.use_prior_columns] = replace_vals.to_numpy()
             retest_df = dataframe[fail_mask].reset_index(drop=True)
-            retest_df["tests_passed"] = self.test_wrap(retest_df)
-            dataframe.loc[fail_mask, "tests_passed"] = retest_df[
-                "tests_passed"
-            ].to_numpy()
+            # FIXME Weizmann: test_wrap() returns the whole dataframe (with a
+            # 'tests_passed' column added), not just that column on its own;
+            # assigning it straight into retest_df["tests_passed"] raised
+            # ValueError: Columns must be same length as key.
+            retest_df = self.test_wrap(retest_df)
+            # FIXME Weizmann: only copying back 'tests_passed' left every
+            # other column (mass_1_source, lambda_1/2, radius_1/2, ...) at
+            # its stale pre-redraw value for rows that got redrawn here.
+            dataframe.loc[fail_mask, retest_df.columns] = retest_df.to_numpy()
 
         raise ValueError(
             f"Redrew {redraws} times, but still {n_fail} failed samples. "
@@ -444,8 +517,11 @@ class NMMAInjectionCreator(InjectionCreator):
 
     def compute_ejecta(self, dataframe):
         """Compute the ejecta parameters for the injections."""
-        # very short wrapper to avoid issues in the initialisation sequence
-        return KilonovaEjectaFitting(dataframe)
+        # FIXME Weizmann: KilonovaEjectaFitting has no __init__ taking a
+        # dataframe argument (only __call__); this raised
+        # TypeError: KilonovaEjectaFitting() takes no arguments.
+        # Instantiate first, then call on the dataframe.
+        return KilonovaEjectaFitting()(dataframe)
 
     # ------------- Legacy functions ----------------#
     def file_to_dataframe(self, injection_file, reference_frequency, trigger_time=0.0):

--- a/nmma/joint/injection_handling.py
+++ b/nmma/joint/injection_handling.py
@@ -6,14 +6,24 @@ from bilby_pipe.utils import convert_string_to_dict
 from bilby_pipe.create_injections import InjectionCreator
 
 
-from ..core.parsing import (parsing_and_logging, slurm_setup_parser, nmma_base_parsing, process_multi_condition_string)
+from ..core.parsing import (
+    parsing_and_logging,
+    slurm_setup_parser,
+    nmma_base_parsing,
+    process_multi_condition_string,
+)
 from ..core.constants import set_cosmology, get_cosmology
 from ..core.utils import set_filename, rejection_sample, read_injection_file
-from ..core.conversion import MultimessengerConversion, KilonovaEjectaFitting, bbh_source_frame
+from ..core.conversion import (
+    MultimessengerConversion,
+    KilonovaEjectaFitting,
+    bbh_source_frame,
+)
 from ..em import utils, lightcurve_handling as lch
 from ..em.model import create_injection_model
 from ..eos.eos_processing import EoSConverter
 from .joint_parsing import injection_parsing
+
 
 class NMMAInjectionCreator(InjectionCreator):
     """A class to create NMMA injections, extending the bilby_pipe InjectionCreator."""
@@ -25,13 +35,13 @@ class NMMAInjectionCreator(InjectionCreator):
             # convert string to dict
             args.prior_dict = convert_string_to_dict(args.prior_dict)
 
-        set_cosmology(getattr(args, 'cosmology', None))
+        set_cosmology(getattr(args, "cosmology", None))
         super().__init__(
             prior_file=args.prior_file,
             prior_dict=args.prior_dict,
             n_injection=args.n_injection,
             default_prior="CBCPriorDict",
-            trigger_time=getattr(args, "trigger_time", 0.),
+            trigger_time=getattr(args, "trigger_time", 0.0),
             deltaT=args.deltaT,
             gpstimes=args.gps_file,
             duration=args.duration,
@@ -43,14 +53,14 @@ class NMMAInjectionCreator(InjectionCreator):
         for key, value in kwargs.items():
             setattr(self, key, value)
 
-        #bilby-pipe injection_creator can only handle dat or json
-        self.extension = 'dat' if args.extension == 'csv' else args.extension
-        self.filename= set_filename(args.injection_file, args)
+        # bilby-pipe injection_creator can only handle dat or json
+        self.extension = "dat" if args.extension == "csv" else args.extension
+        self.filename = set_filename(args.injection_file, args)
 
         if args.simple_setup:
             self.include_checks = False
         else:
-             ## initialise testing methods we want to apply to the injections
+            # initialise testing methods we want to apply to the injections
             self.setup_test_routines(args)
             self.columns_to_remove = None
             self.max_redraws = args.max_redraws
@@ -59,13 +69,15 @@ class NMMAInjectionCreator(InjectionCreator):
             self.setup_post_processing(args)
 
             # we need to be able to do a parameter conversion
-            self.param_conversion = MultimessengerConversion.from_dict(self.conv_instructions)
+            self.param_conversion = MultimessengerConversion.from_dict(
+                self.conv_instructions
+            )
 
             self.original_parameters = args.original_parameters
             self.include_checks = True
 
         # legacy
-        self.gw_injection_file = getattr(args, 'gw_injection_file', self.filename)
+        self.gw_injection_file = getattr(args, "gw_injection_file", self.filename)
         self.reference_frequency = getattr(args, "reference_frequency", 20.0)
 
     def setup_test_routines(self, args):
@@ -74,62 +86,73 @@ class NMMAInjectionCreator(InjectionCreator):
         tests = process_multi_condition_string(args.tests)
 
         for test, val in tests.items():
-            if 'snr' in test:
+            if "snr" in test:
                 self.initialise_ifos(args)
-                self.conv_instructions['gw'] = bbh_source_frame
+                self.conv_instructions["gw"] = bbh_source_frame
                 self.snr_op, self.snr_threshold = val
                 test_methods.append(self.test_snr)
-            elif 'population' in test:
+            elif "population" in test:
                 test_methods.append(self.test_population)
-            elif 'ejecta' in test:
+            elif "ejecta" in test:
                 test_methods.append(self.test_ejecta)
-                self.conv_instructions['ejecta'] = True
-            elif 'peak_magnitude' in test:
+                self.conv_instructions["ejecta"] = True
+            elif "peak_magnitude" in test:
                 self.mag_op, self.ref_mag = val
                 self.initialise_lc_model(args)
-                self.conv_instructions['em'] = self.lc_model.parameter_conversion
+                self.conv_instructions["em"] = self.lc_model.parameter_conversion
                 test_methods.append(self.test_detectability)
 
-        self.conv_instructions['eos'] = EoSConverter(args) 
+        self.conv_instructions["eos"] = EoSConverter(args)
+        # FIXME Weizmann: eos conversion needs mass_1_source/mass_2_source, which are only
+        # computed by the 'gw' step (bbh_source_frame). That step is normally
+        # only added above for an 'snr' test, so make sure it is present
+        # whenever eos conversion is used, regardless of --tests.
+        self.conv_instructions.setdefault("gw", bbh_source_frame)
         if "Hubble_constant" in self.priors:
-            self.conv_instructions['cosmo'] = self.cosmology
+            self.conv_instructions["cosmo"] = self.cosmology
         self.test_routines = test_methods
-                   
+
     def setup_post_processing(self, args):
         postprocess_methods = []
-        if 'snr' in args.post_processing and not hasattr(self, 'snr_threshold'):
+        if "snr" in args.post_processing and not hasattr(self, "snr_threshold"):
             self.initialise_ifos(args)
-            self.conv_instructions['gw'] = bbh_source_frame
+            self.conv_instructions["gw"] = bbh_source_frame
             postprocess_methods.append(self.add_snrs)
-        if 'ejecta' in args.post_processing:
+        if "ejecta" in args.post_processing:
             postprocess_methods.append(self.compute_ejecta)
-        if 'lightcurve' in args.post_processing:
+        if "lightcurve" in args.post_processing:
             self.initialise_lc_model(args)
             postprocess_methods.append(self.prepare_lightcurves)
 
         if not postprocess_methods:
+
             def dummy_postprocess(df):
                 return df
-            postprocess_methods.append(dummy_postprocess) # No-op if no postprocessing is needed
+
+            postprocess_methods.append(
+                dummy_postprocess
+            )  # No-op if no postprocessing is needed
         self.postprocessing = postprocess_methods
-    
+
     def generate_injection_file(self):
-        """Generate the injection file based on the provided parameters."""   
+        """Generate the injection file based on the provided parameters."""
         dataframe = self.generate_prelim_dataframe()
         if self.include_checks:
             dataframe = self.testing_and_postprocessing(dataframe)
 
         # Finally dump the whole thing back into a json injection file
-        self.write_injection_dataframe(dataframe, self.filename, self.extension )    
+        self.write_injection_dataframe(dataframe, self.filename, self.extension)
 
     def generate_prelim_dataframe(self):
-        #step 1: Check: we may want to extend a preliminary injection file
+        # step 1: Check: we may want to extend a preliminary injection file
         # if not, this will be an empty dataframe
-        dataframe_from_file = self.handle_incomplete_injection_file(self.gw_injection_file)
+        dataframe_from_file = self.handle_incomplete_injection_file(
+            self.gw_injection_file
+        )
         if len(dataframe_from_file) > 0:
             self.n_injection = len(dataframe_from_file)
 
-        # If we want to only complement a given injection, there might be an 
+        # If we want to only complement a given injection, there might be an
         # overlap in parameters. In that case, we drop the newly sampled ones
         prior_columns = set(self.priors.keys())
         inj_columns = set(dataframe_from_file.columns.tolist())
@@ -141,24 +164,31 @@ class NMMAInjectionCreator(InjectionCreator):
         self.use_prior_columns = dataframe_from_prior.columns.tolist()
         # if 'index' in use_prior_columns:
         #     use_prior_columns.remove('index')
-        
-        
+
         # combine the dataframes
-        dataframe = pd.DataFrame.merge(dataframe_from_file, dataframe_from_prior,
-            how="outer", ## outer to keep all prior parameters
-            left_index=True, right_index=True )
-        
+        dataframe = pd.DataFrame.merge(
+            dataframe_from_file,
+            dataframe_from_prior,
+            how="outer",  # outer to keep all prior parameters
+            left_index=True,
+            right_index=True,
+        )
+
         # Move dataframe index column to simulation_id if column does not exist
         if "simulation_id" not in dataframe.columns:
-            dataframe = dataframe.reset_index().rename({"index": "simulation_id"}, axis=1)
-        dataframe.astype({'simulation_id': 'int32'})
+            dataframe = dataframe.reset_index().rename(
+                {"index": "simulation_id"}, axis=1
+            )
+        dataframe.astype({"simulation_id": "int32"})
         return dataframe
 
     def adjusted_prior_draw(self):
         dataframe_from_prior = self.get_injection_dataframe()
-        try: ## FIXME: This could be handled more gracefully...
-            swap_mask = dataframe_from_prior["mass_1"] < dataframe_from_prior["mass_2"]    
-            dataframe_from_prior.loc[swap_mask, ['mass_1', 'mass_2']] = dataframe_from_prior.loc[swap_mask, ['mass_2','mass_1']].values
+        try:  # FIXME: This could be handled more gracefully...
+            swap_mask = dataframe_from_prior["mass_1"] < dataframe_from_prior["mass_2"]
+            dataframe_from_prior.loc[
+                swap_mask, ["mass_1", "mass_2"]
+            ] = dataframe_from_prior.loc[swap_mask, ["mass_2", "mass_1"]].values
         except KeyError:
             pass
         if self.columns_to_remove is not None:
@@ -169,14 +199,14 @@ class NMMAInjectionCreator(InjectionCreator):
         # step 3: redraw if necessary until all injections passed the tests
         test_df = self.test_wrap(dataframe)
 
-        if test_df['tests_passed'].all():
+        if test_df["tests_passed"].all():
             dataframe = test_df
             print("All injections passed all tests immediately.")
         else:
-            dataframe['tests_passed'] = test_df['tests_passed']
+            dataframe["tests_passed"] = test_df["tests_passed"]
             dataframe = self.refill_failed_tests(dataframe)
-        dataframe.drop(columns=['tests_passed'], inplace=True)
-  
+        dataframe.drop(columns=["tests_passed"], inplace=True)
+
         # step 4: Wrap things up
         # do final conversion to all necessary parameters if desired
         if not self.original_parameters:
@@ -185,47 +215,60 @@ class NMMAInjectionCreator(InjectionCreator):
         for postprocess in self.postprocessing:
             postprocess(dataframe)
         return dataframe
-    
+
     def test_wrap(self, dataframe):
         test_df = dataframe.copy()
         test_df = self.param_conversion.core_conversion(test_df)
-        test_df['tests_passed'] =self.priors.evaluate_constraints(test_df)
+        # FIXME Weizmann: bilby's PriorDict.evaluate_constraints does `next(iter(sample.values()))`
+        # to get a template array; on a DataFrame, `.values` is an ndarray
+        # property, so `.values()` raises TypeError, which is silently caught
+        # and falls back to `np.ones_like(sample)` over the whole 2D table.
+        # Passing a dict of columns instead keeps that fallback from firing.
+        test_df["tests_passed"] = self.priors.evaluate_constraints(dict(test_df))
         for test_routine in self.test_routines:
             # run the test routine on the test_df
             # this will modify the dataframe in place
             test_routine(test_df)
-        
+
         return test_df
-    
+
     def refill_failed_tests(self, dataframe):
         """Routine to redo tests until all conditions are fulfilled or max_redraws is reached."""
         redraw_from_prior = self.adjusted_prior_draw()
         redraws = 1
         failed_tests = 0
-        while redraws <= self.max_redraws: 
-            fail_mask = ~ dataframe['tests_passed'].astype(bool)
+        while redraws <= self.max_redraws:
+            fail_mask = ~dataframe["tests_passed"].astype(bool)
             n_fail = fail_mask.sum()
             failed_tests += n_fail
-            if n_fail == 0:                 # if all tests passed, break
-                print(f"All injections passed all tests after {redraws-1} redraws,"
-                      f" with {failed_tests} total failed samples.")
+            if n_fail == 0:  # if all tests passed, break
+                print(
+                    f"All injections passed all tests after {redraws - 1} redraws,"
+                    f" with {failed_tests} total failed samples."
+                )
                 return dataframe
-            
+
             if len(redraw_from_prior) < n_fail:
                 redraws += 1
                 extra_draw = self.adjusted_prior_draw()
-                redraw_from_prior = pd.concat([redraw_from_prior, extra_draw], ignore_index=True)
+                redraw_from_prior = pd.concat(
+                    [redraw_from_prior, extra_draw], ignore_index=True
+                )
 
             replace_vals = redraw_from_prior.iloc[:n_fail][self.use_prior_columns]
             redraw_from_prior = redraw_from_prior.iloc[n_fail:]
 
-            dataframe.loc[fail_mask, self.use_prior_columns]=replace_vals.to_numpy()
+            dataframe.loc[fail_mask, self.use_prior_columns] = replace_vals.to_numpy()
             retest_df = dataframe[fail_mask].reset_index(drop=True)
-            retest_df['tests_passed'] = self.test_wrap(retest_df)
-            dataframe.loc[fail_mask, 'tests_passed'] = retest_df['tests_passed'].to_numpy()
+            retest_df["tests_passed"] = self.test_wrap(retest_df)
+            dataframe.loc[fail_mask, "tests_passed"] = retest_df[
+                "tests_passed"
+            ].to_numpy()
 
-        raise ValueError(f"Redrew {redraws} times, but still {n_fail} failed samples. "
-            "Consider increasing the max_redraws or check your prior." )
+        raise ValueError(
+            f"Redrew {redraws} times, but still {n_fail} failed samples. "
+            "Consider increasing the max_redraws or check your prior."
+        )
 
     def handle_incomplete_injection_file(self, gw_injection_file=None):
         # check injection file format
@@ -255,126 +298,177 @@ class NMMAInjectionCreator(InjectionCreator):
 
     def test_population(self, df):
         # FIXME: Allow tests on other distributions
-        
+
         # rejection sampling for uniform mass ratio
-        pop_prob= BNS_distribution(df["mass_1"], df["mass_2"])
-        df["tests_passed"] *= rejection_sample(pop_prob, np.ones_like(pop_prob), self.rng)[1]
+        pop_prob = BNS_distribution(df["mass_1"], df["mass_2"])
+        df["tests_passed"] *= rejection_sample(
+            pop_prob, np.ones_like(pop_prob), self.rng
+        )[1]
         # min mass constraint
-        df["tests_passed"]*=(df["mass_2_source"] >=1.)
+        df["tests_passed"] *= df["mass_2_source"] >= 1.0
 
     def test_ejecta(self, df):
-        df["tests_passed"]*=np.isfinite(df["log10_mej_dyn"]) 
-        df["tests_passed"]*=np.isfinite(df["log10_mej_wind"])
-    
+        df["tests_passed"] *= np.isfinite(df["log10_mej_dyn"])
+        df["tests_passed"] *= np.isfinite(df["log10_mej_wind"])
+
     def test_snr(self, df):
         """Test the SNR of the injections."""
         df = self.add_snrs(df)
-        df["tests_passed"]*= self.snr_op(df["snr"], self.snr_threshold)
-    
+        df["tests_passed"] *= self.snr_op(df["snr"], self.snr_threshold)
+
     def test_detectability(self, df):
         """Test whether the injections are detectable in the light curve model."""
         # FIXME: Extend to respect known systems / filters
         def row_check(data_row):
             _, mags = self.lc_model.gen_detector_lc(data_row)
-            return any([(self.mag_op(mag, self.ref_mag)).any() for mag in mags.values()])
+            return any(
+                [(self.mag_op(mag, self.ref_mag)).any() for mag in mags.values()]
+            )
+
         df["tests_passed"] *= df.apply(lambda row: row_check(row), axis=1)
 
-    #################### Messenger-specific methods ########################
+    # ------------- Messenger-specific methods-----------------------------#
     def initialise_ifos(self, args):
-        if isinstance(args.gw_detectors, str):  
+        if isinstance(args.gw_detectors, str):
             detectors = args.gw_detectors.split(",")
         else:
             detectors = args.gw_detectors
-        dets = [bilby.gw.detector.get_empty_interferometer(det) for det in detectors 
-                     if det != 'ET']
-        if 'ET' in detectors:
-            dets.append(bilby.gw.detector.networks.get_empty_interferometer('ET'))
+        dets = [
+            bilby.gw.detector.get_empty_interferometer(det)
+            for det in detectors
+            if det != "ET"
+        ]
+        if "ET" in detectors:
+            dets.append(bilby.gw.detector.networks.get_empty_interferometer("ET"))
 
         self.ifos = bilby.gw.detector.InterferometerList(dets)
         self.f_min = max(ifo.minimum_frequency for ifo in self.ifos)
         f_max = min(ifo.maximum_frequency for ifo in self.ifos)
 
-        self.sampling_frequency = f_max * 2  
+        self.sampling_frequency = f_max * 2
 
-        default_waveform_arguments = {'reference_frequency': 20.0, 'waveform_approximant': 'IMRPhenomXAS_NRTidalv3', 'minimum_frequency': self.f_min, 'maximum_frequency': f_max}
+        default_waveform_arguments = {
+            "reference_frequency": 20.0,
+            "waveform_approximant": "IMRPhenomXAS_NRTidalv3",
+            "minimum_frequency": self.f_min,
+            "maximum_frequency": f_max,
+        }
         if args.waveform_arguments:
             waveform_arguments = convert_string_to_dict(args.waveform_arguments)
             waveform_arguments = default_waveform_arguments | waveform_arguments
 
-        self.duration = 2048.
+        self.duration = 2048.0
 
         self.waveform_gen = bilby.gw.WaveformGenerator(
-            sampling_frequency=self.sampling_frequency, duration=self.duration,
-            start_time=2-self.duration, time_domain_source_model= None,
+            sampling_frequency=self.sampling_frequency,
+            duration=self.duration,
+            start_time=2 - self.duration,
+            time_domain_source_model=None,
             frequency_domain_source_model=bilby.gw.source.lal_binary_neutron_star,
             parameter_conversion=bilby.gw.conversion.convert_to_lal_binary_neutron_star_parameters,
-            waveform_arguments=waveform_arguments)
+            waveform_arguments=waveform_arguments,
+        )
 
     def add_snrs(self, dataframe):
         """Compute SNR and duration for each row in parallel using threads."""
         # FIXME: preferable to parallelise, but ifo meta_data is not thread-safe
-        
+
         # records = dataframe.to_dict("records")
         # n_workers = min(len(records), os.cpu_count() or 1)
         # with ThreadPool(n_workers) as pool:
         #     results = pool.map(self.compute_snr, records)
 
-        
         # snrs, durations = zip(*results)
         # dataframe[["snr", "duration"]] = np.column_stack((snrs, durations))
 
         dataframe[["snr", "duration"]] = dataframe.apply(
-            lambda row: self.compute_snr(row), axis=1, result_type='expand')
+            lambda row: self.compute_snr(row), axis=1, result_type="expand"
+        )
         return dataframe
-    
+
     def compute_snr(self, data):
-        injection_parameters = {'fiducial': 1. }
-        injection_keys = ('mass_1', 'mass_2','chi_1', 'chi_2', 'luminosity_distance', 'dec', 'ra', 'theta_jn', 'phase', 'theta_jn', 'psi', 'geocent_time', 'lambda_1', 'lambda_2')
-        for k in injection_keys:  
+        injection_parameters = {"fiducial": 1.0}
+        injection_keys = (
+            "mass_1",
+            "mass_2",
+            "chi_1",
+            "chi_2",
+            "luminosity_distance",
+            "dec",
+            "ra",
+            "theta_jn",
+            "phase",
+            "theta_jn",
+            "psi",
+            "geocent_time",
+            "lambda_1",
+            "lambda_2",
+        )
+        for k in injection_keys:
             injection_parameters[k] = data[k]
 
-        self.ifos.set_strain_data_from_zero_noise(self.sampling_frequency, duration=self.duration, start_time=2-self.duration) 
-        self.ifos.inject_signal(injection_parameters, waveform_generator=self.waveform_gen)
-        
+        self.ifos.set_strain_data_from_zero_noise(
+            self.sampling_frequency,
+            duration=self.duration,
+            start_time=2 - self.duration,
+        )
+        self.ifos.inject_signal(
+            injection_parameters, waveform_generator=self.waveform_gen
+        )
 
-        mass_1,mass_2 = injection_parameters['mass_1'], injection_parameters['mass_2']
-        chi_1,chi_2 = injection_parameters['chi_1'], injection_parameters['chi_2']
-        chi_eff = (mass_1 * chi_1 + mass_2 * chi_2)/(mass_1+mass_2) 
-        true_duration = np.rint(bilby.gw.utils.calculate_time_to_merger(self.f_min, mass_1, mass_2, chi=chi_eff))+1
-        return np.sqrt(np.sum([ifo.meta_data['optimal_SNR']**2 for ifo in self.ifos]) ), true_duration
-    
-    
+        mass_1, mass_2 = injection_parameters["mass_1"], injection_parameters["mass_2"]
+        chi_1, chi_2 = injection_parameters["chi_1"], injection_parameters["chi_2"]
+        chi_eff = (mass_1 * chi_1 + mass_2 * chi_2) / (mass_1 + mass_2)
+        true_duration = (
+            np.rint(
+                bilby.gw.utils.calculate_time_to_merger(
+                    self.f_min, mass_1, mass_2, chi=chi_eff
+                )
+            )
+            + 1
+        )
+        return (
+            np.sqrt(np.sum([ifo.meta_data["optimal_SNR"] ** 2 for ifo in self.ifos])),
+            true_duration,
+        )
+
     def initialise_lc_model(self, args):
         self.lc_model = create_injection_model(args)
         self.args.label = args.lc_label if args.lc_label else self.filename
         self.detection_limit = utils.create_detection_limit(args, self.lc_model.filters)
 
     def prepare_lightcurves(self, dataframe):
-        lch.create_multiple_injections(dataframe, self.args, self.lc_model, format= 'standard')
+        lch.create_multiple_injections(
+            dataframe, self.args, self.lc_model, format="standard"
+        )
 
     def compute_ejecta(self, dataframe):
         """Compute the ejecta parameters for the injections."""
         # very short wrapper to avoid issues in the initialisation sequence
         return KilonovaEjectaFitting(dataframe)
-            
 
-    ############################ Legacy functions ##########################
-    def file_to_dataframe(self,injection_file, reference_frequency, trigger_time=0.0
-    ):
+    # ------------- Legacy functions ----------------#
+    def file_to_dataframe(self, injection_file, reference_frequency, trigger_time=0.0):
         """legacy function to convert a bilby- injection file to a dataframe.
         Consider doing a complete nmma-injection instead"""
-        #legacy imports
-        from  lalsimulation import SimInspiralTransformPrecessingWvf2PE as lalsim_conversion
+        # legacy imports
+        from lalsimulation import (
+            SimInspiralTransformPrecessingWvf2PE as lalsim_conversion,
+        )
         from gwpy.table import Table
         from astropy.table import Table as AstroTable
 
         try:
             import ligo.lw  # noqa F401
         except ImportError:
-            raise ImportError("You do not have ligo.lw installed: $ pip install python-ligo-lw")
+            raise ImportError(
+                "You do not have ligo.lw installed: $ pip install python-ligo-lw"
+            )
 
-        if injection_file.endswith((".xml", '.xml.gz')):
-            table = Table.read(injection_file, format="ligolw", tablename="sim_inspiral")
+        if injection_file.endswith((".xml", ".xml.gz")):
+            table = Table.read(
+                injection_file, format="ligolw", tablename="sim_inspiral"
+            )
         elif injection_file.endswith(".dat"):
             table = Table.read(injection_file, format="csv", delimiter="\t")
         elif injection_file.endswith(".ecsv"):
@@ -382,22 +476,60 @@ class NMMAInjectionCreator(InjectionCreator):
         else:
             raise ValueError("Only understand xml, ecsv and dat")
 
-        injection_values = {key: [] for key in ["simulation_id", "mass_1", "mass_2", 
-            "luminosity_distance", "psi", "phase", "geocent_time", "ra", "dec", 
-            "theta_jn", "a_1", "a_2", "tilt_1", "tilt_2", "phi_12", "phi_jl" ]}
+        injection_values = {
+            key: []
+            for key in [
+                "simulation_id",
+                "mass_1",
+                "mass_2",
+                "luminosity_distance",
+                "psi",
+                "phase",
+                "geocent_time",
+                "ra",
+                "dec",
+                "theta_jn",
+                "a_1",
+                "a_2",
+                "tilt_1",
+                "tilt_2",
+                "phi_12",
+                "phi_jl",
+            ]
+        }
         for row in table:
             coa_phase = row.get("coa_phase", 0)
-            spin_args = [row.get("spin1x", 0.0), row.get("spin1y", 0.0), row["spin1z"],
-                         row.get("spin2x", 0.0), row.get("spin2y", 0.0), row["spin2z"]]
+            spin_args = [
+                row.get("spin1x", 0.0),
+                row.get("spin1y", 0.0),
+                row["spin1z"],
+                row.get("spin2x", 0.0),
+                row.get("spin2y", 0.0),
+                row["spin2z"],
+            ]
 
-            precession_args = [row["inclination"], *spin_args,
-                row["mass1"], row["mass2"], reference_frequency, coa_phase]
+            precession_args = [
+                row["inclination"],
+                *spin_args,
+                row["mass1"],
+                row["mass2"],
+                reference_frequency,
+                coa_phase,
+            ]
             conversion_args = [float(arg) for arg in precession_args]
-            conversion_keys = ["theta_jn","phi_jl", "tilt_1" ,"tilt_2", "phi_12", "a_1","a_2"]
-            
-            for key, val in zip(conversion_keys, lalsim_conversion(*conversion_args) ):
+            conversion_keys = [
+                "theta_jn",
+                "phi_jl",
+                "tilt_1",
+                "tilt_2",
+                "phi_12",
+                "a_1",
+                "a_2",
+            ]
+
+            for key, val in zip(conversion_keys, lalsim_conversion(*conversion_args)):
                 injection_values[key].append(val)
-    
+
             injection_values["simulation_id"].append(int(row["simulation_id"]))
             injection_values["luminosity_distance"].append(float(row["distance"]))
             injection_values["psi"].append(float(row.get("polarization", 0)))
@@ -417,6 +549,7 @@ class NMMAInjectionCreator(InjectionCreator):
         injection_values = pd.DataFrame.from_dict(injection_values)
         return injection_values
 
+
 def multi_run_setup():
     args = parsing_and_logging(slurm_setup_parser)
     injection_creator = NMMAInjectionCreator(args)
@@ -430,8 +563,13 @@ def multi_run_setup():
             analysis = file.read()
 
         for key, data in zip(
-            ('PRIOR', 'OUTDIR', 'INJOUT', 'INJNUM'), 
-            (os.path.join(outdir, "injection.prior"), outdir, os.path.join(outdir, "lc.csv"), str(index))
+            ("PRIOR", "OUTDIR", "INJOUT", "INJNUM"),
+            (
+                os.path.join(outdir, "injection.prior"),
+                outdir,
+                os.path.join(outdir, "lc.csv"),
+                str(index),
+            ),
         ):
             analysis = analysis.replace(key, data)
 
@@ -439,29 +577,26 @@ def multi_run_setup():
             file.write(analysis)
 
 
-        
-#### UTILS ######
+# ------------------------------ UTILS ------------------------------#
+
 
 def BNS_distribution(m1, m2):
-    q= m2/m1
-    return np.where(q<=1., q, 1/q)
+    q = m2 / m1
+    return np.where(q <= 1.0, q, 1 / q)
 
 
+# ------------------------------ MAIN ------------------------------#
 
 
-
-
-
-############################ MAIN ###############################
-
-def generate_injection(args = None):
+def generate_injection(args=None):
     # step 0: parse the arguments
     # handle parsing similar to bilby-pipe and parse from config file
     if args is None:
         args = nmma_base_parsing(injection_parsing)
-    
+
     injection_creator = NMMAInjectionCreator(args)
     injection_creator.generate_injection_file()
+
 
 def main(args=None):
     generate_injection(args)

--- a/nmma/joint/injection_handling.py
+++ b/nmma/joint/injection_handling.py
@@ -60,7 +60,7 @@ class NMMAInjectionCreator(InjectionCreator):
         self.filename = set_filename(args.injection_file, args)
 
         # FIXME Weizmann: restores nmma 0.2.3's --binary-type/--eject
-        # behaviour -- see joint_parsing.py's --binary-type help for why
+        # behaviour, see joint_parsing.py's --binary-type help for why
         # this is needed alongside (not instead of) --tests/--post-processing.
         self.binary_type_filter = getattr(args, "binary_type", None)
         if self.binary_type_filter is not None and not getattr(args, "eos_file", None):

--- a/nmma/joint/joint_parsing.py
+++ b/nmma/joint/joint_parsing.py
@@ -1,12 +1,14 @@
-
 from ..core.parsing import nonestr, base_injection_parsing, pipe_inj_parsing
 from ..em.em_parsing import em_analysis_parsing
 from ..eos.eos_parsing import tabulated_eos_parsing, eos_parsing
 from ..gw.gw_parsing import gw_injection_parsing
 
+
 def injection_parsing(parser):
-    
-    parser.description="Create a file of nmma-injections, processing a bilby injection if needed"
+
+    parser.description = (
+        "Create a file of nmma-injections, processing a bilby injection if needed"
+    )
     parser = base_injection_parsing(parser)
     parser = pipe_inj_parsing(parser)
     parser = tabulated_eos_parsing(parser)
@@ -14,61 +16,118 @@ def injection_parsing(parser):
     parser = em_analysis_parsing(parser)
     parser = gw_injection_parsing(parser)
     parser = joint_likelihood_parsing(parser)
-    
-    ### NMMA-added options
-    parser.add_argument("--max-redraws", type=int, default=10,
-        help=("The maximum number of times to redraw the injection "
-              "if additional constraints are not satisfied"), )
-    parser.add_argument("--simple-setup", action='store_true',
-        help= "avoid various complications of the code for tests and post-processing")
-    parser.add_argument("--original-parameters", action='store_true',
-        help="Whether to only store parameters given by injection prior" )
-    parser.add_argument("--post-processing", nargs="*", default=[],
-        help="Postprocessing steps to apply to the injection data." \
-        "Appropriate args need to be specified to. These can be " \
-        "   - 'snr' to append the SNR, requires args for waveform generator" \
-        "   - 'lightcurve' to compute and store an associated lightcurve" )
-    parser.add_argument("--tests", nargs="*", default=[],
-        help="Tests to apply to the injection data. These can be " \
-        "   - 'snr' to calculate the SNR, " \
-        "   - 'detection_limit' to apply the detection limit, " \
-        "   - 'ejecta' to check for ejecta, " \
-        "   - 'peak_magnitude' to check for peak magnitude, or " \
-        "   - 'eos' to check for EOS." \
-        "If not given, no tests are applied."
+
+    # NMMA-added options
+    parser.add_argument(
+        "--max-redraws",
+        type=int,
+        default=10,
+        help=(
+            "The maximum number of times to redraw the injection "
+            "if additional constraints are not satisfied"
+        ),
     )
-    parser.add_argument("-o", "--outdir", default="outdir", 
-        help="Path to the output directory")
-    parser.add_argument("--lc-label", type=nonestr, 
-        help = "optional label for lightcurve-files to be generated;" \
-        "default derives from injection-file")
+    parser.add_argument(
+        "--simple-setup",
+        action="store_true",
+        help="avoid various complications of the code for tests and post-processing",
+    )
+    parser.add_argument(
+        "--original-parameters",
+        action="store_true",
+        help="Whether to only store parameters given by injection prior",
+    )
+    parser.add_argument(
+        "--post-processing",
+        nargs="*",
+        default=[],
+        help="Postprocessing steps to apply to the injection data."
+        "Appropriate args need to be specified to. These can be "
+        "   - 'snr' to append the SNR, requires args for waveform generator"
+        "   - 'lightcurve' to compute and store an associated lightcurve",
+    )
+    parser.add_argument(
+        "--tests",
+        nargs="*",
+        default=[],
+        help="Tests to apply to the injection data. These can be "
+        "   - 'snr' to calculate the SNR, "
+        "   - 'detection_limit' to apply the detection limit, "
+        "   - 'ejecta' to check for ejecta, "
+        "   - 'peak_magnitude' to check for peak magnitude, or "
+        "   - 'eos' to check for EOS."
+        "If not given, no tests are applied.",
+    )
+    parser.add_argument(
+        "-o", "--outdir", default="outdir", help="Path to the output directory"
+    )
+    parser.add_argument(
+        "--lc-label",
+        type=nonestr,
+        help="optional label for lightcurve-files to be generated;"
+        "default derives from injection-file",
+    )
 
-    parser.add_argument("--peak-magnitude", type=nonestr,
-        help="Accept injection only if its peak magnitude matches some setting." \
-        "If 'any', the lightcurve has to pass the detection limit in any filter." \
-        "If 'all', the lightcurve has to pass the detection limit in all filters." \
-        "Can also be a dict of filters and magnitudes that each have to be reached." )
-    parser.add_argument("--eos-file", help="EOS file (radius [km], mass [M_sun], lambda)." )
+    parser.add_argument(
+        "--peak-magnitude",
+        type=nonestr,
+        help="Accept injection only if its peak magnitude matches some setting."
+        "If 'any', the lightcurve has to pass the detection limit in any filter."
+        "If 'all', the lightcurve has to pass the detection limit in all filters."
+        "Can also be a dict of filters and magnitudes that each have to be reached.",
+    )
+    parser.add_argument(
+        "--eos-file", help="EOS file (radius [km], mass [M_sun], lambda)."
+    )
+    parser.add_argument(
+        "--binary-type",
+        type=nonestr,
+        choices=[None, "BNS", "NSBH"],
+        default=None,
+        help="FIXME Weizmann: restores nmma 0.2.3's --binary-type/--eject behaviour, "
+        "removed when injection creation switched to the (redraw-based) --tests/--post-processing "
+        "system, which cannot filter injections whose masses come from an external "
+        "--gw-injection-file (a fixed mass can never be redrawn away from failing a test). "
+        "Requires --eos-file. If given, the corresponding ejecta formula (BNS or NSBH) is "
+        "applied uniformly to every injection, and any injection whose resulting ejecta mass "
+        "is not finite (i.e. the assumed binary type isn't physically consistent with this EOS) "
+        "is dropped -- a one-shot filter, applied once, not a redraw.",
+    )
     # FIXME this is potentially misleading when used in conjunction with full analysis
-    parser.add_argument("--cosmology", 
-        help="Name of the cosmology to be used, see astropy.cosmology for available cosmologies (implicit default: Planck18)")
-    parser.add_argument("--population-model", type=nonestr, default="uniform",
-        help="The population model to be used for injections (default: uniform)")
+    parser.add_argument(
+        "--cosmology",
+        help="Name of the cosmology to be used, see astropy.cosmology for available cosmologies (implicit default: Planck18)",
+    )
+    parser.add_argument(
+        "--population-model",
+        type=nonestr,
+        default="uniform",
+        help="The population model to be used for injections (default: uniform)",
+    )
 
-    
-    ### Parameters for legacy injection file used in conjunction
-    parser.add_argument( "--gw-injection-file", type=nonestr, 
-        help="The xml injection file or bilby injection json file to be used (optional)" )
-    parser.add_argument( "--reference-frequency", type=float, default=20,
-        help="The reference frequency in the provided gw injection file (default: 20)", )
-    
+    # Parameters for legacy injection file used in conjunction
+    parser.add_argument(
+        "--gw-injection-file",
+        type=nonestr,
+        help="The xml injection file or bilby injection json file to be used (optional)",
+    )
+    parser.add_argument(
+        "--reference-frequency",
+        type=float,
+        default=20,
+        help="The reference frequency in the provided gw injection file (default: 20)",
+    )
 
     return parser
+
 
 def joint_likelihood_parsing(parser):
-    parser.description="Set up a joint NMMA likelihood from provided messengers and analysis modifiers"
-    parser.add_argument( "--ejecta-conversion", action='store_true',
-        help="Whether to set up ejecta conversions automatically if ejecta parameters are present" )
+    parser.description = (
+        "Set up a joint NMMA likelihood from provided messengers and analysis modifiers"
+    )
+    parser.add_argument(
+        "--ejecta-conversion",
+        action="store_true",
+        help="Whether to set up ejecta conversions automatically if ejecta parameters are present",
+    )
     return parser
-
-

--- a/nmma/tests/data/Bu2019lm_binary_type_test.prior
+++ b/nmma/tests/data/Bu2019lm_binary_type_test.prior
@@ -1,0 +1,3 @@
+alpha = Gaussian(mu=0., sigma=4e-4, name='alpha', latex_label='$\\alpha$')
+ratio_zeta = Uniform(minimum=0., maximum=1.0, name='zeta',latex_label='$\\ratio-{zeta}$')
+ratio_epsilon = 0.04

--- a/nmma/tests/data/Bu2019lm_binary_type_test.prior
+++ b/nmma/tests/data/Bu2019lm_binary_type_test.prior
@@ -1,3 +1,9 @@
+luminosity_distance = Uniform(minimum=1, maximum=200., name='luminosity_distance',latex_label=r'$d_L$')
+KNphi = Uniform(name='KNphi', minimum=15., maximum=75., latex_label=r'$\Phi$')
+inclination_EM = Sine(name='inclination_EM', minimum=0., maximum=np.pi/2., latex_label=r'$\log\iota$')
+timeshift = Uniform(minimum=-2.0, maximum=0.1, name='trigger_time', latex_label=r'$t_0$')
+log10_mej_dyn  = Uniform(minimum=-3., maximum=-1.0, latex_label= r'$\log_{10}M_{\\rm{dyn}}$')
+log10_mej_wind = Uniform(minimum=-3., maximum=-0.5, latex_label= r'$\log_{10}M_{\\rm{wind}}$')
 alpha = Gaussian(mu=0., sigma=4e-4, name='alpha', latex_label='$\\alpha$')
 ratio_zeta = Uniform(minimum=0., maximum=1.0, name='zeta',latex_label='$\\ratio-{zeta}$')
 ratio_epsilon = 0.04

--- a/nmma/tests/injections.py
+++ b/nmma/tests/injections.py
@@ -8,6 +8,7 @@ from ..em.io import load_em_observations
 from ..em.model import get_lc_model_from_modelname
 from ..core.utils import read_injection_file
 from ..core.parsing import nmma_base_parsing
+from ..core.conversion import BNSEjectaFitting, KilonovaEjectaFitting
 from ..joint import injection_handling, joint_parsing
 
 
@@ -214,6 +215,105 @@ def test_injections():
         lightcurveInjectionTest(model_name)
 
 
+def test_eos_injection_without_snr_test():
+    """FIXME Weizmann: regression test, using the real Bu2019lm.prior +
+    example_files/sim_events/bns_O4_injections.dat combination reported in
+    the original bug (nmma-create-injection --eos-file ... --gw-injection-file
+    ... with no --tests/--post-processing snr), for bugs in
+    NMMAInjectionCreator that only trigger when simple_setup=False (i.e.
+    setup_test_routines/test_wrap actually run, unlike the other tests in
+    this file, which all use simple_setup=True and so never exercised this
+    code path):
+
+    1. EoSConverter needs mass_1_source/mass_2_source, but the 'gw' step
+       that computes them (bbh_source_frame) used to only get added to
+       conv_instructions for an 'snr' test/post-processing. Using
+       --eos-file without an snr test raised
+       KeyError('mass_1_source') in EoSConverter.system_props_from_eos.
+    2. test_wrap() used to call self.priors.evaluate_constraints(test_df)
+       with a pandas DataFrame. bilby's evaluate_constraints does
+       next(iter(sample.values())) to get a template array; DataFrame.values
+       is an ndarray property, so calling it raises TypeError, silently
+       caught by evaluate_constraints, which then falls back to
+       np.ones_like(sample) over the whole 2D table instead of a 1D
+       per-row array, raising
+       ValueError: Expected a 1D array, got an array with shape (N, n_cols)
+       when assigned back into test_df['tests_passed'].
+    3. refill_failed_tests() did retest_df["tests_passed"] = self.test_wrap(
+       retest_df), but test_wrap() returns the whole dataframe, not just
+       that column, raising ValueError: Columns must be same length as key.
+    4. testing_and_postprocessing()'s redraw branch only copied the
+       'tests_passed' column back onto the pre-conversion dataframe, and
+       refill_failed_tests() only copied 'tests_passed' back for redrawn
+       rows: with --original-parameters (which skips the final
+       core_conversion pass), mass_1_source/lambda_1/2/radius_1/2 ended up
+       silently missing from the output whenever at least one row needed a
+       redraw.
+    """
+    workingDir = os.path.dirname(__file__)
+    dataDir = os.path.join(workingDir, "data")
+    test_directory = os.path.join(dataDir, "eos_injection_no_snr_test")
+    priorDir = os.path.join(workingDir, "../../priors/")
+    exampleFilesDir = os.path.join(workingDir, "../../example_files/")
+    if os.path.isdir(test_directory):
+        shutil.rmtree(test_directory, ignore_errors=True)
+    os.makedirs(test_directory, exist_ok=True)
+
+    prior_path = os.path.join(priorDir, "Bu2019lm.prior")
+    assert os.path.exists(prior_path), "prior file does not exist"
+
+    # bns_O4_injections.dat has 2000 rows and some masses well above ALF2's
+    # ~2.09 Msun TOV mass (unphysical for this EOS, and slow to run through
+    # in full for a unit test); keep only a couple of rows with masses
+    # safely inside ALF2's range.
+    full_dat_path = os.path.join(exampleFilesDir, "sim_events", "bns_O4_injections.dat")
+    assert os.path.exists(full_dat_path), "example gw-injection-file does not exist"
+    gw_injection_path = os.path.join(test_directory, "bns_O4_injections_subset.dat")
+    with open(full_dat_path) as f:
+        lines = f.readlines()
+    header, rows = lines[0], lines[1:]
+    selected = [
+        row
+        for row in rows
+        if all(float(x) < 2.0 for x in row.split("\t")[5:7])  # mass1, mass2
+    ][:2]
+    assert len(selected) == 2, "could not find 2 rows with safe masses"
+    with open(gw_injection_path, "w") as f:
+        f.writelines([header] + selected)
+
+    injection_name = os.path.join(test_directory, "eos_injection.json")
+
+    args = nmma_base_parsing(joint_parsing.injection_parsing, [])
+    non_default_args = dict(
+        prior_file=prior_path,
+        gw_injection_file=gw_injection_path,
+        injection_file=injection_name,
+        eos_file="example_files/eos/ALF2.dat",
+        original_parameters=True,
+        generation_seed=42,
+    )
+    for key, value in non_default_args.items():
+        setattr(args, key, value)
+
+    # simple_setup defaults to False here: this must go through
+    # setup_test_routines/testing_and_postprocessing/test_wrap, not skip them.
+    injection_handling.generate_injection(args)
+
+    assert os.path.exists(injection_name), "injection file does not exist"
+    injection_dict = read_injection_file(injection_name)
+    for key in (
+        "mass_1_source",
+        "mass_2_source",
+        "lambda_1",
+        "lambda_2",
+        "radius_1",
+        "radius_2",
+    ):
+        assert key in injection_dict, f"{key} missing from generated injection"
+
+    shutil.rmtree(test_directory, ignore_errors=True)
+
+
 def test_validate_lightcurves():
     print("validate_lightcurve test")
 
@@ -251,3 +351,169 @@ def test_validate_lightcurves():
     assert not lch.validate_lightcurve(
         **vars(args)
     ), "Test for setting cutoff time failed"
+
+
+def test_bns_ejecta_conversion_rejects_non_ns_component():
+    """FIXME Weizmann: regression test for a bug in BNSEjectaFitting.bns_ejecta_conversion.
+
+    radius_1/radius_2 are 0 (not a real Schwarzschild radius) for a mass
+    outside the EOS's tabulated range, so compactness = mass*geom_msun_km/radius
+    is inf for that component. dynamic_mass_fitting_KrFo/log10_disk_mass_fitting
+    clip negative fit values via np.maximum(0, .), which silently turned that
+    inf into a finite mdyn_fit=0.0 before np.isfinite() downstream had any
+    chance to notice, log10(0 + alpha) then came out as an ordinary finite
+    number for a system that isn't actually a BNS under this EOS. Verified
+    directly against the exact formula: with mass_1_source=2.5 (above ALF2's
+    ~2.09 Msun TOV mass) and radius_1=0, this used to return a finite
+    log10_mej_dyn instead of -inf.
+    """
+    fitter = BNSEjectaFitting()
+    params = dict(
+        mass_1_source=np.array([2.5]),
+        mass_2_source=np.array([1.3]),
+        radius_1=np.array([0.0]),  # outside ALF2's mass range -> not a NS
+        radius_2=np.array([13.1]),
+        alpha=np.array([0.04]),
+        ratio_zeta=np.array([0.5]),
+        TOV_mass=np.array([2.0854]),
+        R_16=np.array([12.0]),
+    )
+    log10_mej_dyn, log10_mej_wind, log10_mej_total, _ = fitter.bns_ejecta_conversion(
+        params
+    )
+    assert not np.isfinite(
+        log10_mej_dyn[0]
+    ), "log10_mej_dyn should be -inf when mass_1 isn't a real NS under this EOS"
+    assert not np.isfinite(
+        log10_mej_wind[0]
+    ), "log10_mej_wind should be -inf when mass_1 isn't a real NS under this EOS"
+    assert not np.isfinite(log10_mej_total[0])
+
+
+def test_kilonova_ejecta_fitting_requires_both_components_to_be_ns():
+    """FIXME Weizmann: regression test for KilonovaEjectaFitting's routing.
+
+    It used to route to bns_parameter_conversion whenever radius_1>0 alone,
+    without also checking radius_2>0. mass_1 >= mass_2 by convention, so
+    radius_1>0 usually implies radius_2>0 too (a lighter mass is inside the
+    EOS's mass range whenever a heavier one is), but not always: mass_2
+    can fall below the EOS table's tabulated minimum while mass_1 is a
+    valid NS mass, and that row was still (wrongly) treated as BNS,
+    silently publishing a finite ejecta mass instead of -inf (see
+    test_bns_ejecta_conversion_rejects_non_ns_component for why the
+    formula itself doesn't reliably catch this on its own).
+    """
+    # two rows, to force numpy's vectorized np.where routing path (the
+    # if/elif scalar path only ever runs for single-injection calls, which
+    # the real pipeline, always operating on a whole dataframe, never
+    # does; a length-1 array can be truth-tested directly by numpy without
+    # raising, so it wouldn't actually exercise the routing bug here)
+    fitter = KilonovaEjectaFitting()
+    params = dict(
+        mass_1_source=np.array([1.8, 1.4]),
+        mass_2_source=np.array([1.3, 1.3]),
+        radius_1=np.array([13.0, 13.2]),  # row 0: >0, would wrongly route to BNS alone
+        radius_2=np.array(
+            [0.0, 13.1]
+        ),  # row 0: <=0, mass_2 isn't a real NS; row 1: genuine BNS
+        alpha=np.array([0.04, 0.04]),
+        ratio_zeta=np.array([0.5, 0.5]),
+        TOV_mass=np.array([2.0854, 2.0854]),
+        R_16=np.array([12.0, 12.0]),
+        # np.where evaluates both the bns_ and nsbh_parameter_conversion
+        # branches eagerly for every row (only the result is masked
+        # afterwards), so nsbh_parameter_conversion's inputs must be valid
+        # for all rows too, even the ones that will end up routed to BNS.
+        chi_1=np.array([0.0, 0.0]),
+    )
+    (
+        log10_mej_dyn,
+        log10_mej_wind,
+        log10_mej_total,
+        _,
+    ) = fitter.ejecta_parameter_conversion(params)
+    assert not np.isfinite(log10_mej_dyn[0]), "invalid secondary should give -inf"
+    assert not np.isfinite(log10_mej_wind[0]), "invalid secondary should give -inf"
+    assert not np.isfinite(log10_mej_total[0]), "invalid secondary should give -inf"
+    assert np.isfinite(
+        log10_mej_dyn[1]
+    ), "a genuine BNS row should not be affected by the fix"
+
+
+def test_binary_type_filter_end_to_end():
+    """FIXME Weizmann: end-to-end regression test for --binary-type, which
+    restores nmma 0.2.3's --binary-type/--eject behaviour: apply a single
+    ejecta formula uniformly to every injection and drop (one-shot, no
+    redraw) those whose resulting ejecta mass isn't finite. This is the
+    only mechanism that can filter injections read from an external
+    --gw-injection-file: --tests/Constraint-based filtering only works by
+    redrawing samples, and a mass read from a file is fixed, so it can
+    never be redrawn away from failing a test (see
+    test_eos_injection_without_snr_test's module docstring era discussion;
+    reproduced directly against the CLI here instead).
+
+    Also checks that --binary-type overwrites log10_mej_dyn/log10_mej_wind
+    even when the prior already samples them directly (nmma 0.2.3 had no
+    "prefer the already-sampled value" behaviour, it always overwrote).
+    """
+    workingDir = os.path.dirname(__file__)
+    dataDir = os.path.join(workingDir, "data")
+    test_directory = os.path.join(dataDir, "binary_type_filter_test")
+    exampleFilesDir = os.path.join(workingDir, "../../example_files/")
+    if os.path.isdir(test_directory):
+        shutil.rmtree(test_directory, ignore_errors=True)
+    os.makedirs(test_directory, exist_ok=True)
+
+    # Self-contained fixture (only alpha/ratio_zeta/ratio_epsilon, the
+    # nuisance parameters bns_ejecta_conversion needs) rather than the
+    # user's own priors/Bu2019lm_ejecta.prior: masses/luminosity_distance
+    # come from gw_injection_path below, not the prior, for this test.
+    prior_path = os.path.join(dataDir, "Bu2019lm_binary_type_test.prior")
+    assert os.path.exists(prior_path), "prior file does not exist"
+
+    # First 5 rows of the real, tracked example file: a known, fixed mix of
+    # one BNS-under-ALF2, one NSBH-under-ALF2 and one BBH-under-ALF2 event
+    # (masses verified by hand against ALF2's ~2.0854 Msun TOV mass).
+    full_dat_path = os.path.join(exampleFilesDir, "sim_events", "bns_O4_injections.dat")
+    assert os.path.exists(full_dat_path), "example gw-injection-file does not exist"
+    gw_injection_path = os.path.join(test_directory, "bns_subset.dat")
+    with open(full_dat_path) as f:
+        lines = f.readlines()
+    with open(gw_injection_path, "w") as f:
+        f.writelines(lines[:6])  # header + first 5 rows
+
+    injection_name = os.path.join(test_directory, "binary_type_injection.json")
+
+    args = nmma_base_parsing(joint_parsing.injection_parsing, [])
+    non_default_args = dict(
+        prior_file=prior_path,
+        gw_injection_file=gw_injection_path,
+        injection_file=injection_name,
+        eos_file="example_files/eos/ALF2.dat",
+        original_parameters=True,
+        generation_seed=42,
+        binary_type="BNS",
+    )
+    for key, value in non_default_args.items():
+        setattr(args, key, value)
+
+    injection_handling.generate_injection(args)
+
+    assert os.path.exists(injection_name), "injection file does not exist"
+    injection_dict = read_injection_file(injection_name)
+    n_kept = len(injection_dict)
+    assert n_kept > 0, "--binary-type BNS filtered out every injection"
+    assert n_kept < 5, (
+        "--binary-type BNS should drop the non-BNS rows in this fixed "
+        "5-row mix, not keep all of them (would indicate the prior's "
+        "pre-sampled log10_mej_dyn/log10_mej_wind are being kept instead "
+        "of being overwritten by the EOS-derived value)"
+    )
+    for radius_1, radius_2 in zip(
+        injection_dict["radius_1"], injection_dict["radius_2"]
+    ):
+        assert radius_1 > 0 and radius_2 > 0, (
+            "every kept injection must have both components be a real NS " "under ALF2"
+        )
+
+    shutil.rmtree(test_directory, ignore_errors=True)


### PR DESCRIPTION
Fixes a KeyError on mass_1_source/mass_2_source reported by @np699 : EoS conversion needs these fields, but they were only computed when an `snr` test was requested. Now the `gw` conversion step always runs when EoS conversion is used.

@Hen42rik  Could you please take a look? I left two `# FIXME Weizmann:` comments in the code. If everything looks correct, please feel free to remove them, and I will merge the PR.
Thanks 
