### PR TITLE
Fix FiestaModel/FiestaGRBModel imports for fiestaEM>=0.2.2

### DIFF
--- a/nmma/em/model.py
+++ b/nmma/em/model.py
@@ -20,6 +20,7 @@ from ..core.conversion import (
     get_cosmo_grids,
 )
 from ..core.gitlab import get_models_home, get_model
+from pathlib import Path
 
 ln10 = np.log(10)
 
@@ -430,28 +431,61 @@ class LightCurveModelContainer:
 
 
 class FiestaModel(LightCurveModelContainer):
-    def __init__(self, fiesta_model, filters, sample_times=None, **kwargs):
+    
+    load_dir_string = None
+    
+    def __init__(self, model, filters=None, surrogate_dir=None, sample_times=None, **kwargs):
         """A light curve model object for evaluating light curves using fiesta.
 
         Parameters
         ----------
-        fiesta_model: fiesta.inference.lightcurve_model.SurrogateModel
-            The fiesta model to use.
+        model: str
+            Name of the fiesta surrogate model to load.
         filters: str or list of str, optional
             Filters to use for the light curve. Defaults to all trained filters.
+        surrogate_dir: str, optional
+            Path to the directory containing the surrogate models.
         sample_times: array_like, optional
             Unused, included for compatibility with other Models.
         **kwargs
             Additional keyword arguments for LightCurveModelContainer, might be unused.
         """
 
-        self.fiesta_model = fiesta_model
-        if filters is None:
-            filters = fiesta_model.filters
+        # fiesta requires a non-empty in-range filter list at construction;
+        # there is no "all trained filters" default. Pick a safe optical/NIR
+        # set that fits every published Bu* surrogate.
+        # FIXME: investigate better ways to do this
+        filters = (
+            list(filters)
+            if filters
+            else [
+                "sdssg",
+                "sdssr",
+                "sdssi",
+                "sdssz",
+                "ztfg",
+                "ztfr",
+                "ztfi",
+                "2massj",
+                "2massh",
+                "2massks",
+            ]
+        )
+
+        fiesta_kwargs = dict(
+            name=model,
+            filters=filters,
+            directory=surrogate_dir,
+        )
+        try:
+            self.fiesta_model = FluxModel(**fiesta_kwargs)
+        except OSError:
+            fiesta_kwargs["directory"] = Path(surrogate_dir, self.load_dir_string, model, "model")
+            self.fiesta_model = FluxModel(**fiesta_kwargs)
         if sample_times is not None:
             print("Warning: sample_times are not used in FiestaModel, ignoring.")
-        kwargs["model_parameters"] = fiesta_model.parameter_names
-        super().__init__(fiesta_model.name, filters, **kwargs)
+        kwargs["model_parameters"] = self.fiesta_model.parameter_names
+        super().__init__(self.fiesta_model.name, filters, **kwargs)
 
     def setup_model_times(self):
         return self.fiesta_model.times  # default sample times for fiesta model
@@ -776,41 +810,9 @@ class FiestaKilonovaModel(FiestaModel):
         A light curve model object to evaluate the light curve
         from a set of parameters.
     """
-
-    def __init__(self, model="Bu2026_MLP", filters=None, surrogate_dir=None, **kwargs):
-        # fiesta requires a non-empty in-range filter list at construction;
-        # there is no "all trained filters" default. Pick a safe optical/NIR
-        # set that fits every published Bu* surrogate.
-        fiesta_filters = (
-            list(filters)
-            if filters
-            else [
-                "sdssg",
-                "sdssr",
-                "sdssi",
-                "sdssz",
-                "ztfg",
-                "ztfr",
-                "ztfi",
-                "2massj",
-                "2massh",
-                "2massks",
-            ]
-        )
-        fiesta_kwargs = dict(
-            name=model,
-            filters=fiesta_filters,
-            directory=surrogate_dir,
-        )
-        
-        # FIXME: specify directory after https://github.com/nuclear-multimessenger-astronomy/fiestaEM/pull/75
-        try:
-            fiesta_model = FluxModel(**fiesta_kwargs)
-        except OSError:
-            fiesta_kwargs["directory"] = f"{surrogate_dir}/KN/{model}/model"
-            fiesta_model = FluxModel(**fiesta_kwargs)
-
-        super().__init__(fiesta_model, filters, **kwargs)
+    load_dir_string = "KN"
+    def __init__(self, model="Bu2026_MLP", **kwargs):
+        super().__init__(model, **kwargs)
 
 
 class GRBMixin:
@@ -878,24 +880,11 @@ class FiestaGRBModel(GRBMixin, FiestaModel):
         A light curve model object to evaluate the light curve
         from a set of parameters.
     """
-
+    load_dir_string ="GRB"
     def __init__(
-        self, model="afgpy_gaussian_CVAE", filters=None, surrogate_dir=None, **kwargs
+        self, model="afgpy_gaussian_CVAE", **kwargs
     ):
-        fiesta_kwargs = dict(
-            name=model,
-            filters=filters,
-            directory=surrogate_dir,
-        )
-        
-        # FIXME: specify directory after https://github.com/nuclear-multimessenger-astronomy/fiestaEM/pull/75
-        try:
-            fiesta_model = FluxModel(**fiesta_kwargs)
-        except OSError:
-            fiesta_kwargs["directory"] = f"{surrogate_dir}/GRB/{model}/model"
-            fiesta_model = FluxModel(**fiesta_kwargs)
-
-        super().__init__(fiesta_model, filters, **kwargs)
+        super().__init__(model, **kwargs)
 
 
 class GRBLightCurveModel(GRBMixin, LightCurveModelContainer):

--- a/nmma/em/model.py
+++ b/nmma/em/model.py
@@ -779,10 +779,10 @@ class FiestaKilonovaModel(FiestaModel):
     def __init__(self, model="Bu2026_MLP", filters=None, surrogate_dir=None, **kwargs):
         if model.endswith("_lc"):
             from fiesta.inference.lightcurve_model import (
-                BullaLightcurveModel as BullaSurrogate,
+                LightcurveModel as BullaSurrogate,
             )
         else:
-            from fiesta.inference.lightcurve_model import BullaFlux as BullaSurrogate
+            from fiesta.inference.lightcurve_model import FluxModel as BullaSurrogate
         # fiesta requires a non-empty in-range filter list at construction;
         # there is no "all trained filters" default. Pick a safe optical/NIR
         # set that fits every published Bu* surrogate.
@@ -885,7 +885,7 @@ class FiestaGRBModel(GRBMixin, FiestaModel):
     def __init__(
         self, model="afgpy_gaussian_CVAE", filters=None, surrogate_dir=None, **kwargs
     ):
-        from fiesta.inference.lightcurve_model import AfterglowFlux
+        from fiesta.inference.lightcurve_model import FluxModel
 
         fiesta_kwargs = dict(
             name=model,
@@ -893,10 +893,10 @@ class FiestaGRBModel(GRBMixin, FiestaModel):
             directory=surrogate_dir,
         )
         try:
-            fiesta_model = AfterglowFlux(**fiesta_kwargs)
+            fiesta_model = FluxModel(**fiesta_kwargs)
         except OSError:
             fiesta_kwargs["directory"] = f"{surrogate_dir}/GRB/{model}/model"
-            fiesta_model = AfterglowFlux(**fiesta_kwargs)
+            fiesta_model = FluxModel(**fiesta_kwargs)
 
         super().__init__(fiesta_model, filters, **kwargs)
 

--- a/nmma/em/model.py
+++ b/nmma/em/model.py
@@ -7,6 +7,7 @@ import sncosmo
 from sncosmo.models import _SOURCES
 from ast import literal_eval
 from bilby.gw.cosmology import get_cosmology
+from fiesta.inference.lightcurve_model import FluxModel
 from . import utils
 from . import lightcurve_generation as lc_gen
 
@@ -777,12 +778,6 @@ class FiestaKilonovaModel(FiestaModel):
     """
 
     def __init__(self, model="Bu2026_MLP", filters=None, surrogate_dir=None, **kwargs):
-        if model.endswith("_lc"):
-            from fiesta.inference.lightcurve_model import (
-                LightcurveModel as BullaSurrogate,
-            )
-        else:
-            from fiesta.inference.lightcurve_model import FluxModel as BullaSurrogate
         # fiesta requires a non-empty in-range filter list at construction;
         # there is no "all trained filters" default. Pick a safe optical/NIR
         # set that fits every published Bu* surrogate.
@@ -807,11 +802,13 @@ class FiestaKilonovaModel(FiestaModel):
             filters=fiesta_filters,
             directory=surrogate_dir,
         )
+        
+        # FIXME: specify directory after https://github.com/nuclear-multimessenger-astronomy/fiestaEM/pull/75
         try:
-            fiesta_model = BullaSurrogate(**fiesta_kwargs)
+            fiesta_model = FluxModel(**fiesta_kwargs)
         except OSError:
             fiesta_kwargs["directory"] = f"{surrogate_dir}/KN/{model}/model"
-            fiesta_model = BullaSurrogate(**fiesta_kwargs)
+            fiesta_model = FluxModel(**fiesta_kwargs)
 
         super().__init__(fiesta_model, filters, **kwargs)
 
@@ -885,13 +882,13 @@ class FiestaGRBModel(GRBMixin, FiestaModel):
     def __init__(
         self, model="afgpy_gaussian_CVAE", filters=None, surrogate_dir=None, **kwargs
     ):
-        from fiesta.inference.lightcurve_model import FluxModel
-
         fiesta_kwargs = dict(
             name=model,
             filters=filters,
             directory=surrogate_dir,
         )
+        
+        # FIXME: specify directory after https://github.com/nuclear-multimessenger-astronomy/fiestaEM/pull/75
         try:
             fiesta_model = FluxModel(**fiesta_kwargs)
         except OSError:


### PR DESCRIPTION
fiestaEM 0.2.2 removed the BullaFlux/BullaLightcurveModel/AfterglowFlux aliases in favor of their base classes FluxModel/LightcurveModel, breaking FiestaKilonovaModel and FiestaGRBModel construction. Swap the imports to the base classes, which have identical constructor signatures.

Fixes #440


Claude-Session: https://claude.ai/code/session_01LJicefHMKSM62v4wxtbS6U